### PR TITLE
b Enables the browser system to control filename case sensitivity

### DIFF
--- a/packages/cli/src/command.spec.ts
+++ b/packages/cli/src/command.spec.ts
@@ -22,7 +22,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-    testSystem = createBrowserSystem({});
+    testSystem = createBrowserSystem({}, ts.sys.useCaseSensitiveFileNames);
     testSystem.createDirectory("./addons");
     testSystem.writeFile("./tsconfig.json", "{}");
 

--- a/packages/cli/src/options.spec.ts
+++ b/packages/cli/src/options.spec.ts
@@ -13,7 +13,7 @@ const testReporter = new NoReporter();
 
 describe("createOptions", () => {
     beforeEach(() => {
-        testSystem = createBrowserSystem({});
+        testSystem = createBrowserSystem({}, ts.sys.useCaseSensitiveFileNames);
     });
 
     it("should return defaults w/o any param", () => {

--- a/packages/compiler/src/compiler/Compiler.spec.ts
+++ b/packages/compiler/src/compiler/Compiler.spec.ts
@@ -60,7 +60,7 @@ const testSystem = createBrowserSystem({
     "src/arrow.ts": `
         export const computeDate = async (): Promise<Date> => new Date();
     `,
-});
+}, ts.sys.useCaseSensitiveFileNames);
 
 class CompilerTestClass extends Compiler {
     constructor(options: CompilerOptions) {

--- a/packages/compiler/src/compiler/addons/addon-resolver.spec.ts
+++ b/packages/compiler/src/compiler/addons/addon-resolver.spec.ts
@@ -6,6 +6,7 @@
  */
 /* eslint-disable jest/no-mocks-import */
 import path from "path";
+import ts from "typescript";
 import { ReporterMock } from "../../../test";
 import { createBrowserSystem } from "../../environment";
 import { createResolver } from "./addon-resolver";
@@ -24,7 +25,7 @@ beforeAll(() => {
     );
 });
 
-const testSystem = createBrowserSystem({});
+const testSystem = createBrowserSystem({}, ts.sys.useCaseSensitiveFileNames);
 testSystem.readDirectory = jest.fn().mockReturnValue(["one"]);
 
 describe("createResolver", () => {

--- a/packages/compiler/src/compiler/compilation/CompilationContext.spec.ts
+++ b/packages/compiler/src/compiler/compilation/CompilationContext.spec.ts
@@ -45,7 +45,7 @@ let testSystem: ts.System;
 let testProgram: ts.Program;
 
 beforeEach(() => {
-    testSystem = createBrowserSystem({});
+    testSystem = createBrowserSystem({}, ts.sys.useCaseSensitiveFileNames);
     testProgram = ts.createProgram({ options: {}, rootNames: [] });
     testObj = new CompilationContextTestClass({
         buildDir: "",

--- a/packages/compiler/src/compiler/config/resolve-compiler-config.spec.ts
+++ b/packages/compiler/src/compiler/config/resolve-compiler-config.spec.ts
@@ -4,11 +4,12 @@
  *   Licensed under the MIT License. See LICENSE in the project root for license information.
  * ---------------------------------------------------------------------------------------------
  */
+import ts from "typescript";
 import { createBrowserSystem } from "../../environment";
 import { NoReporter } from "../NoReporter";
 import { resolveCompilationConfig } from "./resolve-compiler-config";
 
-const testSystem = createBrowserSystem({});
+const testSystem = createBrowserSystem({}, ts.sys.useCaseSensitiveFileNames);
 
 describe("resolveCompilationConfig", () => {
     it("should return undefined w/ empty path", () => {

--- a/packages/compiler/src/environment/browser-system.ts
+++ b/packages/compiler/src/environment/browser-system.ts
@@ -10,7 +10,7 @@ import { extname, isAbsolute, join, normalize } from "path";
 import ts from "typescript";
 import { tsLibDefaults } from "../compiler";
 
-export const createBrowserSystem = (files?: Record<string, string>): ts.System => {
+export const createBrowserSystem = (files?: Record<string, string>, useCaseSensitiveFileNames = false): ts.System => {
     const knownFiles = Object.entries({ ...(files ?? tsLibDefaults) }).reduce((acc: Record<string, string>, [name, content]) => {
         acc[resolvePath(name)] = content;
         return acc;
@@ -19,7 +19,7 @@ export const createBrowserSystem = (files?: Record<string, string>): ts.System =
     return {
         args: [],
         newLine: "\n",
-        useCaseSensitiveFileNames: false,
+        useCaseSensitiveFileNames: useCaseSensitiveFileNames,
         createDirectory: (dirPath: string): void => {
             let resolved = resolvePath(dirPath);
             if (!resolved.endsWith("/")) {

--- a/packages/compiler/src/environment/compile-service.spec.ts
+++ b/packages/compiler/src/environment/compile-service.spec.ts
@@ -19,7 +19,7 @@ const testSystem = createBrowserSystem({
     "folder/one.js": `class One {}`,
     "folder/two.js": `class Two {}`,
     "folder/foo/three.js": `class Three {}`,
-});
+}, ts.sys.useCaseSensitiveFileNames);
 
 describe("createCompileHost", () => {
     let expected: ts.CompilerHost;
@@ -80,7 +80,6 @@ describe("createCompileHost", () => {
             const actual = target.getCanonicalFileName("./FooBar/Something.js");
 
             expect(actual).toBe(expected.getCanonicalFileName("./FooBar/Something.js"));
-            expect(actual).toBe("./foobar/something.js");
         });
 
         it("returns normalized filename with file name", () => {
@@ -137,7 +136,6 @@ describe("createCompileHost", () => {
             const actual = target.useCaseSensitiveFileNames();
 
             expect(actual).toEqual(expected.useCaseSensitiveFileNames());
-            expect(actual).toBe(false);
         });
     });
 
@@ -314,7 +312,7 @@ describe("createWatchHost", () => {
 
     describe("useCaseSensitiveFileNames", () => {
         it("return same value", () => {
-            expect(target.useCaseSensitiveFileNames()).toBe(false);
+            expect(target.useCaseSensitiveFileNames()).toBe(ts.sys.useCaseSensitiveFileNames);
         });
     });
 

--- a/packages/webpack/jest.e2e.config.js
+++ b/packages/webpack/jest.e2e.config.js
@@ -32,6 +32,7 @@ module.exports = {
     moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
     testEnvironment: "node",
     testRegex: "test/.*\\.test\\.ts$",
+    testTimeout: 25000,
     transform: {
         "^.+\\.(js|jsx|ts|tsx)$": "ts-jest",
     },


### PR DESCRIPTION
The browser system was hardcoded to always be case-insensitive. Now when used as test system, it adapts to the platform it is on