### PR TITLE
b** Correctly set the program instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@quatico/websmith",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "description": "A compiler frontend for the TypeScript compiler",
     "keywords": [
         "typescript",


### PR DESCRIPTION
To ensure consistent states in the AddonContext provided to addons, the ts.Program instance is now guaranteed to be provided during the compiler constructor.

A minor extraction refactoring was executed to add test coverage to ensure CompilationContext creation consistency regarding the AddonContext API.