### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 # Bug Report
 
 <!--
-  Please fill in each section completely. Thank you!
+  Please fill in a reproducible description, including preconditions.
 -->
 
 ### 🔎 Search Terms

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: Bug report
+about: 'Create a report to help us improve websmith '
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+# Bug Report
+
+<!--
+  Please fill in each section completely. Thank you!
+-->
+
+### 🔎 Search Terms
+
+<!--
+  What search terms did you use when trying to find an existing bug report?
+  List them here so people in the future can find this one more easily.
+-->
+
+### 🕗 Version & Regression Information
+
+<!-- When did you start seeing this bug occur?
+
+Please keep and fill in the line that best applies:
+-->
+- This is a blocker
+- This changed between versions ______ and _______
+- This is the behavior in every version I tried
+- I was unable to test this on prior versions because _______
+
+### 💻 Code
+
+<!-- Please post the relevant code sample here as well-->
+```ts
+// We can quickly address your report if:
+//  - The code sample is short.
+//  - It doesn't use external libraries.
+//  - The incorrectness of the behavior is readily apparent from reading the sample.
+// Reports are slower to investigate if:
+//  - We have to pare too much extraneous code.
+//  - We have to clone a large repo and validate that the problem isn't elsewhere.
+//  - The sample is confusing or doesn't clearly demonstrate what's wrong.
+```
+
+### 🙁 Actual behavior
+
+<!-- What happened, and why it was wrong -->
+
+### 🙂 Expected behavior
+
+<!-- What you expected to happen instead, and why -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ assignees: ''
 # Suggestion
 
 <!--
-  Please fill in each section completely. Thank you!
+  Your reason or motivation to create this proposal.
 -->
 
 ## ✅ Viability Checklist

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,44 @@
+---
+name: Feature request
+about: Suggest an idea for websmith
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+# Suggestion
+
+<!--
+  Please fill in each section completely. Thank you!
+-->
+
+## ✅ Viability Checklist
+
+<!--
+   The more criteria a suggestion meets, the more likely it is to be accepted.
+-->
+My suggestion meets these guidelines:
+
+* [ ] This wouldn't be a breaking change in existing websmith addons
+* [ ] This wouldn't negatively impact the performance of the websmith build process without opt-in
+
+
+## ⭐ Suggestion
+
+<!-- A summary of what you'd like to see added or changed -->
+
+## 📃 Motivating Example
+
+<!--
+  If you were announcing this feature in a blog post, what's a short explanation that shows
+  a developer why this feature improves webpack?
+-->
+
+## 💻 Use Cases
+
+<!--
+  What do you want to use this for?
+  What shortcomings exist with current approaches?
+  What workarounds are you using in the meantime?
+-->


### PR DESCRIPTION
I would like to propose to start with these minimal bug and feature request templates to ease the creation of the corresponding types of issues in the future and to serve as a base for additional types of issues where we see corresponding added value.