### PR TITLE
E Removes the bundled dependency in favor of full dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@quatico/websmith",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "description": "A compiler frontend for the TypeScript compiler",
     "keywords": [
         "typescript",
@@ -49,6 +49,7 @@
     },
     "devDependencies": {
         "@cucumber/gherkin": "^25.0.2",
+        "@nrwl/nx-cloud": "latest",
         "@swc/core": "1.3.14",
         "@swc/jest": "0.2.23",
         "@types/glob": "^7.1.3",
@@ -70,12 +71,11 @@
         "lerna": "^6.0.3",
         "license-check-and-add": "4.0.5",
         "memfs": "^3.4.1",
+        "nx": "^15.2.1",
         "prettier": "^2.6.2",
         "rimraf": "3.0.2",
         "ts-jest": "^29.0.3",
-        "ts-node": "^10.9.1",
-        "nx": "^15.2.1",
-        "@nrwl/nx-cloud": "latest"
+        "ts-node": "^10.9.1"
     },
     "dependencies": {
         "commander": "^9.4.1",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -64,9 +64,6 @@
         "tslib": "2.4.1",
         "typescript": "~4.6.4"
     },
-    "bundleDependencies": [
-        "@quatico/websmith-core"
-    ],
     "engines": {
         "node": ">=16.x",
         "yarn": ">=1.20.x"


### PR DESCRIPTION
This addresses the error 'warning "@quatico/websmith-compiler@0.3.5" is missing a bundled dependency "@quatico/websmith-core". This should be reported to the package maintainer.' otherwise received by users of websmith-compiler (for example @quatico/magellan-cli)