### PR TITLE
Solve wrong peerDedendency to core

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -60,7 +60,7 @@
         "webpack-cli": "^4.9.1"
     },
     "peerDependencies": {
-        "@quatico/websmith-core": "0.3.4",
+        "@quatico/websmith-core": "0.3.5",
         "webpack": "^5.75.0"
     },
     "engines": {


### PR DESCRIPTION
Solve warning  " > @quatico/websmith-webpack@0.3.5" has incorrect peer dependency "@quatico/websmith-core@0.3.4".