### PR TITLE
t Removes dependencies to project's filesystem from unit tests

### DIFF
--- a/packages/compiler/src/command.spec.ts
+++ b/packages/compiler/src/command.spec.ts
@@ -8,38 +8,19 @@
 import { WarnMessage } from "@quatico/websmith-api";
 import { Compiler, CompilerAddon, createBrowserSystem, NoReporter } from "@quatico/websmith-core";
 import { Command } from "commander";
-import path, { join, normalize, resolve } from "path";
-import ts from "typescript";
+import path from "path";
 import { addCompileCommand, hasInvalidTargets } from "./command";
 import { createOptions } from "./options";
 
-let testSystem: ts.System;
-let origCwd: string;
-
-beforeAll(() => {
-    origCwd = process.cwd();
-    process.chdir(join(__dirname, ".."));
-});
+let testSystem;
 
 beforeEach(() => {
-    testSystem = createBrowserSystem({}, ts.sys.useCaseSensitiveFileNames);
-    testSystem.createDirectory("./addons");
-    testSystem.writeFile("./tsconfig.json", "{}");
-
-    // TODO: Find a better approach. We need to do this with the virtual test system to ensure, that we do not use the websmith tsconfig.json as they will resolve dozens to hundreds of filenames
-    let testDir = normalize(join(process.cwd(), "test"));
-    if (!testDir.includes(join("compiler", "test"))) {
-        testDir = testDir.replace(testDir.slice(testDir.indexOf("test")), join("packages", "compiler", testDir.slice(testDir.indexOf("test"))));
-    }
-});
-
-afterAll(() => {
-    process.chdir(origCwd);
+    testSystem = emptySystem();
 });
 
 describe("addCompileCommand", () => {
-    it("should create additionalArguments map w/ unknown argument", () => {
-        const target = new Compiler(createOptions({}, new NoReporter()));
+    it("should yield additionalArguments w/ unknown argument", () => {
+        const target = new Compiler(createOptions({}, new NoReporter(), testSystem), testSystem);
         const testObj = addCompileCommand(new Command(), target);
 
         testObj.parse(
@@ -65,8 +46,8 @@ describe("addCompileCommand", () => {
         );
     });
 
-    it("should yield default options w/o config and CLI arguments", () => {
-        const target = new Compiler(createOptions({}, new NoReporter()));
+    it("should yield default options w/o config and w/o CLI arguments", () => {
+        const target = new Compiler(createOptions({}, new NoReporter(), testSystem), testSystem);
 
         addCompileCommand(new Command(), target).parse([], { from: "user" });
 
@@ -79,78 +60,42 @@ describe("addCompileCommand", () => {
         );
         expect(actual.buildDir).toEqual(expect.stringContaining(path.sep));
         expect(actual.watch).toBe(false);
-        expect(actual.config).toBeUndefined();
+        expect(actual.config).toEqual({ configFilePath: "/websmith.config.json" });
         expect(actual.debug).toBe(false);
         const compilerOptions = {
-            allowJs: true,
-            allowSyntheticDefaultImports: true,
-            alwaysStrict: true,
-            configFilePath: resolve("tsconfig.json"),
-            declaration: true,
-            declarationMap: true,
-            downlevelIteration: true,
-            emitDecoratorMetadata: true,
-            esModuleInterop: true,
-            experimentalDecorators: true,
-            importHelpers: true,
-            incremental: true,
+            configFilePath: "/tsconfig.json",
             inlineSources: undefined,
-            module: 1,
-            moduleResolution: 2,
-            noEmit: false,
-            noEmitOnError: true,
-            noImplicitAny: true,
-            noImplicitReturns: true,
-            noImplicitThis: true,
-            noUnusedLocals: true,
-            outDir: join(__dirname, "..", "bin"),
-            pretty: true,
-            removeComments: false,
-            resolveJsonModule: true,
-            skipLibCheck: false,
+            outDir: "/lib",
             sourceMap: false,
-            strict: true,
-            strictBindCallApply: true,
-            strictFunctionTypes: true,
-            strictNullChecks: true,
-            strictPropertyInitialization: true,
-            target: 99,
-            types: ["node", "jest"],
-            useUnknownInCatchVariables: true,
         };
         expect(actual.project).toEqual(compilerOptions);
 
         expect({ wildcardDirectories: {}, ...actual.tsconfig }).toEqual({
             options: compilerOptions,
-            errors: [],
+            errors: [
+                {
+                    category: 1,
+                    code: 18003,
+                    file: undefined,
+                    length: undefined,
+                    messageText:
+                        "No inputs were found in config file '/tsconfig.json'. Specified 'include' paths were '[\"**/*\"]' and 'exclude' paths were '[]'.",
+                    reportsDeprecated: undefined,
+                    reportsUnnecessary: undefined,
+                    start: undefined,
+                },
+            ],
             typeAcquisition: {
                 include: [],
                 exclude: [],
                 enable: false,
             },
-            fileNames: [
-                `${join(__dirname, "CompilerArguments.ts")}`,
-                `${join(__dirname, "bin.ts")}`,
-                `${join(__dirname, "command.ts")}`,
-                `${join(__dirname, "compiler-system.ts")}`,
-                `${join(__dirname, "find-config.ts")}`,
-                `${join(__dirname, "index.ts")}`,
-                `${join(__dirname, "options.ts")}`,
-            ],
+            fileNames: [],
             compileOnSave: false,
             projectReferences: undefined,
-            raw: {
-                compilerOptions: {
-                    module: "CommonJS",
-                    noEmit: false,
-                    outDir: "./bin",
-                },
-                exclude: ["src/**/*.spec.ts"],
-                extends: "../../tsconfig.json",
-                include: ["src/**/*.ts"],
-            },
+            raw: {},
             watchOptions: undefined,
-            wildcardDirectories: { [join(__dirname, "..", "src")]: 1 },
+            wildcardDirectories: { [""]: 1 },
         });
         expect(actual.reporter).toBeDefined();
         expect(actual.sourceMap).toBe(false);
@@ -158,7 +103,7 @@ describe("addCompileCommand", () => {
         expect(actual.watch).toBe(false);
     });
 
-    it("should set config option w/ --config cli argument", () => {
+    it("should yield config option w/ --config cli argument", () => {
         testSystem.writeFile("./expected/websmith.config.json", "{}");
         const target = new Compiler(createOptions({}, new NoReporter()), testSystem);
 
@@ -167,7 +112,7 @@ describe("addCompileCommand", () => {
         expect(target.getOptions().config?.configFilePath).toEqual(expect.stringContaining("/expected/websmith.config.json"));
     });
 
-    it("should set project option w/ --project cli argument", () => {
+    it("should yield project option w/ --project cli argument", () => {
         testSystem.writeFile("expected/tsconfig.json", "{}");
         const target = new Compiler(createOptions({}, new NoReporter()), testSystem);
 
@@ -176,24 +121,23 @@ describe("addCompileCommand", () => {
         expect(target.getOptions().project.configFilePath).toEqual(expect.stringContaining("/expected/tsconfig.json"));
     });
 
-    it("should set sourceMap option w/ --sourceMap cli argument", () => {
-        const target = new Compiler(createOptions({}, new NoReporter()));
+    it("should yield sourceMap option w/ --sourceMap cli argument", () => {
+        const target = new Compiler(createOptions({}, new NoReporter(), testSystem), testSystem);
 
         addCompileCommand(new Command(), target).parse(["--sourceMap"], { from: "user" });
 
         expect(target.getOptions().sourceMap).toBe(true);
     });
 
-    it("should set debug compiler option w/ --debug cli argument", () => {
-        const target = new Compiler(createOptions({}, new NoReporter()));
+    it("should yield debug compiler option w/ --debug cli argument", () => {
+        const target = new Compiler(createOptions({}, new NoReporter(), testSystem), testSystem);
 
         addCompileCommand(new Command(), target).parse(["--debug"], { from: "user" });
 
         expect(target.getOptions().debug).toBe(true);
     });
 
-    // TODO: This test is failing because the compiler watch support is broken.
-    it.skip("should set watch compiler option w/ --watch cli argument", () => {
+    it("should yield watch compiler option w/ --watch cli argument", () => {
         const target = new Compiler(createOptions({}, new NoReporter()));
 
         addCompileCommand(new Command(), target).parse(["--watch"], { from: "user" });
@@ -201,16 +145,7 @@ describe("addCompileCommand", () => {
         expect(target.getOptions().watch).toBe(true);
     });
 
-    it("should execute compile w/o --watch cli argument", () => {
-        const target = new Compiler(createOptions({}, new NoReporter()));
-        target.compile = jest.fn();
-
-        addCompileCommand(new Command(), target).parse([], { from: "user" });
-
-        expect(target.compile).toHaveBeenCalled();
-    });
-
-    it("should set transpileOnly option w/ --transpileOnly cli argument", () => {
+    it("should yield transpileOnly option w/ --transpileOnly cli argument", () => {
         testSystem.writeFile("expected/tsconfig.json", "{}");
         const target = new Compiler(createOptions({}, new NoReporter()), testSystem);
 
@@ -219,31 +154,52 @@ describe("addCompileCommand", () => {
         expect(target.getOptions().transpileOnly).toBe(true);
     });
 
-    // TODO: This test requires a decision regarding our explicit logic for additional cmdline arguments - do provide them through the CompilerOptions or do we reject them.
-    it.skip("should inform CLI user about tsconfig usage for unsupported command line arguments", () => {
+    it("should yield additionalArguments w/ unsupported cli arguments", () => {
         console.error = line => {
             throw new Error(line.toString());
         };
-        const target = new Compiler(createOptions({}, new NoReporter()));
+        const target = new Compiler(createOptions({}, new NoReporter(), testSystem), testSystem);
 
-        expect(() => addCompileCommand(new Command(), target).parse(["--debug", "--allowJs", "--strict"], { from: "user" })).toThrow(
-            `Unknown Argument "--allowJs".` + `\nIf this is a tsc command, please configure it in your typescript configuration file.\n`
+        addCompileCommand(new Command(), target).parse(["--debug", "--allowJs", "--strict"], { from: "user" });
+
+        expect(target.getOptions().additionalArguments).toEqual(
+            new Map([
+                ["allowJs", true],
+                ["strict", true],
+            ])
         );
+    });
+
+    it("should call compile w/o --watch cli argument", () => {
+        const target = new Compiler(createOptions({}, new NoReporter()));
+        target.compile = jest.fn();
+
+        addCompileCommand(new Command(), target).parse([], { from: "user" });
+
+        expect(target.compile).toHaveBeenCalled();
+    });
+
+    it("should call watch w/ --watch cli argument", () => {
+        const target = new Compiler(createOptions({}, new NoReporter()));
+        target.watch = jest.fn();
+
+        addCompileCommand(new Command(), target).parse(["--watch"], { from: "user" });
+
+        expect(target.watch).toHaveBeenCalled();
     });
 });
 
 describe("addCompileCommand#addons", () => {
-    it("should show warning w/ --addonsDir cli argument and non-existing path", () => {
-        const target = new Compiler(createOptions({}, new NoReporter()));
+    it("should yield warning w/ --addonsDir cli argument to non-existing path", () => {
+        const target = new Compiler(createOptions({}, new NoReporter(), testSystem), testSystem);
         target.getReporter().reportDiagnostic = jest.fn();
 
         addCompileCommand(new Command(), target).parse(["--addonsDir", "./unknown"], { from: "user" });
 
-        expect(target.getReporter().reportDiagnostic).toHaveBeenCalledWith(new WarnMessage('Addons directory "./unknown" does not exist.'));
+        expect(target.getReporter().reportDiagnostic).toHaveBeenCalledWith(new WarnMessage('Addons directory "/unknown" does not exist.'));
     });
 
-    it("should add addon name to addons w/ --addons cli argument and known name", () => {
-        testSystem.writeFile("./addons/expected/addon.ts", "export const activate = () => {};");
+    it("should yield options addons w/ --addons cli argument and existing addon", () => {
         jest.mock(
             "/addons/expected/addon",
             () => {
@@ -251,8 +207,8 @@ describe("addCompileCommand#addons", () => {
             },
             { virtual: true }
         );
-
-        const target = new Compiler(createOptions({}, new NoReporter()), testSystem);
+        testSystem.writeFile("./addons/expected/addon.ts", "export const activate = () => {};");
+        const target = new Compiler(createOptions({}, new NoReporter(), testSystem), testSystem);
 
         addCompileCommand(new Command(), target).parse(["--addons", "expected"], { from: "user" });
 
@@ -264,7 +220,7 @@ describe("addCompileCommand#addons", () => {
         ).toEqual(["expected"]);
     });
 
-    it("should add addon name to addons w/ --addons cli argument and multiple known names", () => {
+    it("should yield options addons w/ --addons cli argument and multiple existing addons", () => {
         testSystem.writeFile("./addons/zip/addon.ts", "export const activate = () => {};");
         testSystem.writeFile("./addons/zap/addon.ts", "export const activate = () => {};");
         testSystem.writeFile("./addons/zup/addon.ts", "export const activate = () => {};");
@@ -291,8 +247,7 @@ describe("addCompileCommand#addons", () => {
             },
             { virtual: true }
         );
-
-        const target = new Compiler(createOptions({}, new NoReporter()), testSystem);
+        const target = new Compiler(createOptions({}, new NoReporter(), testSystem), testSystem);
 
         addCompileCommand(new Command(), target).parse(["--addons", "zip, zap, zup"], { from: "user" });
 
@@ -304,18 +259,18 @@ describe("addCompileCommand#addons", () => {
         ).toEqual(["zip", "zap", "zup"]);
     });
 
-    it("should not add addon name to addons w/ --addons cli argument and unknown name", () => {
-        const target = new Compiler(createOptions({}, new NoReporter()));
+    it("should yield empty options addons w/ --addons cli argument and non-existing addon", () => {
+        const target = new Compiler(createOptions({}, new NoReporter(), testSystem), testSystem);
 
         addCompileCommand(new Command(), target).parse(["--addons", "unknown"], { from: "user" });
 
         expect(target.getOptions().addons.getAddons()).toEqual([]);
     });
 
-    it("should not add unkonwn addon name to addons w/ --addons cli argument, known and unknown name", () => {
-        testSystem.writeFile("./addons/known/addon.ts", "export const activate = () => {};");
+    it("should not yield non-existing options addons w/ --addons cli argument, existing and non-existing addons", () => {
+        testSystem.writeFile("./addons/expected/addon.ts", "export const activate = () => {};");
         jest.mock(
-            "/addons/known/addon",
+            "/addons/expected/addon",
             () => {
                 return { activate: jest.fn() };
             },
@@ -324,18 +279,18 @@ describe("addCompileCommand#addons", () => {
 
         const target = new Compiler(createOptions({}, new NoReporter()), testSystem);
 
-        addCompileCommand(new Command(), target).parse(["--addons", "unknown, known"], { from: "user" });
+        addCompileCommand(new Command(), target).parse(["--addons", "unknown, expected"], { from: "user" });
 
         expect(
             target
                 .getOptions()
                 .addons.getAddons()
                 .map((it: CompilerAddon) => it.name)
-        ).toEqual(["known"]);
+        ).toEqual(["expected"]);
     });
 
-    it("should show warning w/ --addons cli argument and unknown name", () => {
-        const target = new Compiler(createOptions({}, new NoReporter()));
+    it("should yield warning w/ --addons cli argument and non-existing addon name", () => {
+        const target = new Compiler(createOptions({}, new NoReporter(), testSystem), testSystem);
         target.getReporter().reportDiagnostic = jest.fn();
 
         addCompileCommand(new Command(), target).parse(["--addons", "unknown"], { from: "user" });
@@ -343,10 +298,10 @@ describe("addCompileCommand#addons", () => {
         expect(target.getReporter().reportDiagnostic).toHaveBeenCalledWith(new WarnMessage('Missing addons: "unknown".'));
     });
 
-    it("should show warning w/ --addons cli argument, known and unknown name", () => {
-        testSystem.writeFile("./addons/known/addon.ts", "export const activate = () => {};");
+    it("should yield warning w/ --addons cli argument, existing and non-existing addons", () => {
+        testSystem.writeFile("./addons/existing/addon.ts", "export const activate = () => {};");
         jest.mock(
-            "/addons/known/addon",
+            "/addons/existing/addon",
             () => {
                 return { activate: jest.fn() };
             },
@@ -356,12 +311,12 @@ describe("addCompileCommand#addons", () => {
         const target = new Compiler(createOptions({}, new NoReporter()), testSystem);
         target.getReporter().reportDiagnostic = jest.fn();
 
-        addCompileCommand(new Command(), target).parse(["--addons", "known, unknown"], { from: "user" });
+        addCompileCommand(new Command(), target).parse(["--addons", "existing, unknown"], { from: "user" });
 
         expect(target.getReporter().reportDiagnostic).toHaveBeenCalledWith(new WarnMessage('Missing addons: "unknown".'));
     });
 
-    it("should use addonsDir and addons from compiler config w/o cli argument override", () => {
+    it("should yield addonsDir and addons from compiler config w/o any cli argument", () => {
         testSystem.writeFile("/expected/one/addon.ts", "export const activate = () => {};");
         jest.mock(
             "/expected/one/addon",
@@ -402,24 +357,24 @@ describe("addCompileCommand#addons", () => {
 });
 
 describe("addCompileCommand#targets", () => {
-    it("should set targets w/ single targets cli argument", () => {
-        const target = new Compiler(createOptions({}, new NoReporter()));
+    it("should yield options targets w/ --targets cli argument and single value", () => {
+        const target = new Compiler(createOptions({ project: "./tsconfig.json" }, new NoReporter(), testSystem), testSystem);
 
         addCompileCommand(new Command(), target).parse(["--targets", "expected"], { from: "user" });
 
         expect(target.getOptions().targets).toEqual(["expected"]);
     });
 
-    it("should set target w/ comma separated targets cli argument", () => {
-        const target = new Compiler(createOptions({}, new NoReporter()));
+    it("should yield options targets w/ --targets cli argument and comma separated values", () => {
+        const target = new Compiler(createOptions({}, new NoReporter(), testSystem), testSystem);
 
         addCompileCommand(new Command(), target).parse(["--targets", "one, two, three"], { from: "user" });
 
         expect(target.getOptions().targets).toEqual(["one", "two", "three"]);
     });
 
-    it("should show warning w/ --targets cli argument and unknown name", () => {
-        const target = new Compiler(createOptions({}, new NoReporter()));
+    it("should yield warning w/ --targets cli argument and unknown name", () => {
+        const target = new Compiler(createOptions({}, new NoReporter(), testSystem), testSystem);
         target.getReporter().reportDiagnostic = jest.fn();
 
         addCompileCommand(new Command(), target).parse(["--targets", "unknown"], { from: "user" });
@@ -431,7 +386,7 @@ describe("addCompileCommand#targets", () => {
         );
     });
 
-    it("should not show any warning w/ --targets cli argument and known names", () => {
+    it("should not yield any warning w/ --targets cli argument and known names", () => {
         testSystem.writeFile("./websmith.config.json", '{ "targets": {"expected": {}} }');
         const target = new Compiler(createOptions({}, new NoReporter()), testSystem);
         target.getReporter().reportDiagnostic = jest.fn();
@@ -441,7 +396,7 @@ describe("addCompileCommand#targets", () => {
         expect(target.getReporter().reportDiagnostic).not.toHaveBeenCalled();
     });
 
-    it("should not show any warning w/ --targets cli argument and multiple known names", () => {
+    it("should not yield any warning w/ --targets cli argument and multiple known names", () => {
         testSystem.writeFile("./websmith.config.json", '{ "targets": {"zip": {}, "zap": {}, "zup": {}} }');
         const target = new Compiler(createOptions({}, new NoReporter()), testSystem);
         target.getReporter().reportDiagnostic = jest.fn();
@@ -451,7 +406,7 @@ describe("addCompileCommand#targets", () => {
         expect(target.getReporter().reportDiagnostic).not.toHaveBeenCalled();
     });
 
-    it("should show warning w/ --targets cli argument, known and unknown names", () => {
+    it("should yield warning w/ --targets cli argument, known and unknown names", () => {
         testSystem.writeFile("./websmith.config.json", '{ "targets": {"whatever": {}, "known": {}} }');
         const target = new Compiler(createOptions({}, new NoReporter()), testSystem);
         target.getReporter().reportDiagnostic = jest.fn();
@@ -465,7 +420,7 @@ describe("addCompileCommand#targets", () => {
         );
     });
 
-    it("should show warning w/ --targets cli argument, known name but missing addons for target", () => {
+    it("should yield warning w/ --targets cli argument, known name but missing addons for target", () => {
         testSystem.writeFile("./websmith.config.json", '{ "targets": {"known": { "addons": ["missing"]}} }');
         const target = new Compiler(createOptions({}, new NoReporter()), testSystem);
         target.getReporter().reportDiagnostic = jest.fn();
@@ -476,7 +431,7 @@ describe("addCompileCommand#targets", () => {
         expect(target.getReporter().reportDiagnostic).toHaveBeenCalledWith(new WarnMessage('Missing addons for target "known": "missing".'));
     });
 
-    it("should show warning w/ --targets cli argument, multiple known names but missing addons for targets", () => {
+    it("should yield warning w/ --targets cli argument, multiple known names but missing addons for targets", () => {
         testSystem.writeFile(
             "./websmith.config.json",
             '{ "targets": {"zip": { "addons": ["missing1"]}, "zap": { "addons": ["missing2"]}, "zup": { "addons": ["missing3"]}} }'
@@ -541,3 +496,11 @@ describe("hasInvalidTargets", () => {
         ).toBe(true);
     });
 });
+
+const emptySystem = () => {
+    const result = createBrowserSystem();
+    result.writeFile("./tsconfig.json", "{}");
+    result.writeFile("./websmith.config.json", "{}");
+    result.createDirectory("./addons");
+    return result;
+};


### PR DESCRIPTION
This PR attempts to provide proper unit tests for the CLI command:

+ Introduce empty compile system
+ Fix skipped tests
+ Use proper naming scheme for unit tests