### PR TITLE
Lifecycle fixes for AddonRegistry

### DIFF
--- a/packages/compiler/src/command.spec.ts
+++ b/packages/compiler/src/command.spec.ts
@@ -97,7 +97,7 @@ describe("addCompileCommand", () => {
         });
         expect(actual.reporter).toBeDefined();
         expect(actual.sourceMap).toBe(false);
-        expect(actual.targets).toEqual(["*"]);
+        expect(actual.targets).toEqual([]);
         expect(actual.watch).toBe(false);
     });
 

--- a/packages/compiler/src/command.spec.ts
+++ b/packages/compiler/src/command.spec.ts
@@ -213,7 +213,7 @@ describe("addCompileCommand#addons", () => {
 
         addCompileCommand(new Command(), target).parse(["--addons", "expected"], { from: "user" });
 
-        expect(addons.refresh().getAvailableAddons().getNames()).toEqual(["expected"]);
+        expect(addons.getAvailableAddons("*").getNames()).toEqual(["expected"]);
     });
 
     it("should yield options addons w/ --addons cli argument and multiple existing addons", () => {
@@ -225,7 +225,7 @@ describe("addCompileCommand#addons", () => {
 
         addCompileCommand(new Command(), target).parse(["--addons", "zip, zap, zup"], { from: "user" });
 
-        expect(addons.refresh().getAvailableAddons().getNames()).toEqual(["zip", "zap", "zup"]);
+        expect(addons.getAvailableAddons("*").getNames()).toEqual(["zip", "zap", "zup"]);
     });
 
     it("should yield empty options addons w/ --addons cli argument and non-existing addon", () => {
@@ -234,7 +234,7 @@ describe("addCompileCommand#addons", () => {
 
         addCompileCommand(new Command(), target).parse(["--addons", "unknown"], { from: "user" });
 
-        expect(addons.getAvailableAddons()).toHaveLength(0);
+        expect(addons.getAvailableAddons("*")).toHaveLength(0);
     });
 
     it("should not yield non-existing options addons w/ --addons cli argument, existing and non-existing addons", () => {
@@ -244,7 +244,7 @@ describe("addCompileCommand#addons", () => {
 
         addCompileCommand(new Command(), target).parse(["--addons", "unknown, expected"], { from: "user" });
 
-        expect(addons.refresh().getAvailableAddons().getNames()).toEqual(["expected"]);
+        expect(addons.getAvailableAddons("*").getNames()).toEqual(["expected"]);
     });
 
     it("should yield warning w/ --addons cli argument and non-existing addon name", () => {

--- a/packages/compiler/src/command.ts
+++ b/packages/compiler/src/command.ts
@@ -53,7 +53,7 @@ export const addCompileCommand = (parent = program, compiler?: Compiler): Comman
             if (unknownArgs?.length > 0) {
                 options.additionalArguments = parseUnknownArguments(unknownArgs);
             }
-            if (hasInvalidTargets(options.targets, options.config)) {
+            if (options.targets && hasInvalidTargets(options.targets, options.config)) {
                 reporter.reportDiagnostic(
                     new WarnMessage(
                         `Custom target configuration "${options.targets.join(", ")}" found, but no target provided.\n` +
@@ -98,7 +98,7 @@ const addonConfig = (command: Command, compilationConfig?: CompilationConfig, op
     addonsDir:
         command.opts().addonsDir && command.opts().addonsDir !== "./addons" ? command.opts().addonsDir : compilationConfig?.addonsDir ?? "./addons",
 
-    targets: options?.config?.targets,
+    ...(!!options?.config?.targets && { targets: options?.config?.targets }),
 });
 
 export const hasInvalidTargets = (targets?: string[], config?: CompilationConfig) => {

--- a/packages/compiler/src/options.spec.ts
+++ b/packages/compiler/src/options.spec.ts
@@ -16,7 +16,6 @@ describe("createOptions", () => {
             expect.objectContaining({
                 debug: false,
                 sourceMap: false,
-                targets: ["*"],
                 watch: false,
             })
         );
@@ -119,7 +118,6 @@ describe("createOptions", () => {
                 outDir: "/lib",
             },
 
-            targets: ["*"],
             tsconfig: {
                 fileNames: ["/expected/one/addon.ts"],
                 errors: [],

--- a/packages/compiler/src/options.spec.ts
+++ b/packages/compiler/src/options.spec.ts
@@ -54,7 +54,7 @@ describe("createOptions", () => {
             { virtual: true }
         );
 
-        const actual = addons.refresh().getAvailableAddons("*");
+        const actual = addons.getAvailableAddons("*");
 
         expect(actual.getNames()).toEqual(["addon-foo"]);
     });
@@ -90,10 +90,11 @@ describe("createOptions", () => {
     });
 
     it("should return config w/ valid addonsDir, addons in compiler config json", () => {
-        const { addons } = compileSystem({
+        const { fileSystem: target } = compileSystem({
             files: {
-                "./expected/one/addon.js": "export const activate = () => {};",
-                "./websmith.config.json": '{ "addons":["one", "two"], "addonsDir":"./expected" }',
+                "./tsconfig.json": '{ "include": ["**/*.ts"] }',
+                "/expected/one/addon.ts": "export const activate = () => {};",
+                "websmith.config.json": '{ "addons":["one", "two"], "addonsDir":"./expected" }',
             },
         });
         jest.mock(
@@ -104,20 +105,31 @@ describe("createOptions", () => {
             { virtual: true }
         );
 
-        const actual = addons.refresh();
+        const actual = createOptions({ config: "./websmith.config.json" }, new NoReporter(), target);
 
         expect(actual).toMatchObject({
-            availableAddons: new Map(
-                Object.entries({
-                    one: {
-                        activate: expect.any(Function),
-                        getName: expect.any(Function),
-                    },
-                })
-            ),
+            buildDir: "/",
             config: {
-                addonsDir: "./expected",
                 addons: ["one", "two"],
+                addonsDir: "/expected",
+                configFilePath: "/websmith.config.json",
+            },
+            project: {
+                configFilePath: "/tsconfig.json",
+                outDir: "/lib",
+            },
+
+            targets: ["*"],
+            tsconfig: {
+                fileNames: ["/expected/one/addon.ts"],
+                errors: [],
+                options: {
+                    configFilePath: "/tsconfig.json",
+                    outDir: "/lib",
+                },
+                raw: {
+                    include: ["**/*.ts"],
+                },
             },
         });
     });

--- a/packages/compiler/src/options.ts
+++ b/packages/compiler/src/options.ts
@@ -22,7 +22,6 @@ const DEFAULTS = {
     outDir: "./lib",
     project: "./tsconfig.json",
     sourceMap: false,
-    targets: "*",
     watch: false,
 };
 
@@ -55,7 +54,7 @@ export const createOptions = (args: CompilerArguments, reporter = new NoReporter
         project: tsconfig.options,
         reporter,
         sourceMap: args.sourceMap ?? DEFAULTS.sourceMap,
-        targets: resolveTargets(args.targets || DEFAULTS.targets, compilationConfig, reporter),
+        targets: resolveTargets(args.targets, compilationConfig, reporter),
         transpileOnly: args.transpileOnly ?? compilationConfig?.transpileOnly ?? false,
         watch: args.watch ?? DEFAULTS.watch,
     };

--- a/packages/core/src/compiler/Compiler.spec.ts
+++ b/packages/core/src/compiler/Compiler.spec.ts
@@ -167,6 +167,41 @@ describe("compile", () => {
             "
         `);
     });
+
+    it("yields output w/ with addons but w/o targets", () => {
+        const { fileSystem } = compileSystem({
+            "src/target.ts": `
+                export const computeDate = async (): Promise<Date> => new Date();
+            `,
+        });
+
+        new CompilerTestClass(
+            {
+                buildDir: "./src",
+                reporter: new ReporterMock(fileSystem),
+                debug: false,
+                sourceMap: false,
+                transpileOnly: false,
+                watch: false,
+                project: {
+                    module: ts.ModuleKind.ESNext,
+                    target: ts.ScriptTarget.Latest,
+                    configFilePath: "./tsconfig.json",
+                },
+                tsconfig: {
+                    options: {},
+                    fileNames: fileSystem.readDirectory("./src"),
+                    errors: [],
+                },
+            },
+            fileSystem
+        ).compile();
+
+        expect(fileSystem.readFile("/src/target.js")).toMatchInlineSnapshot(`
+            "export const computeDate = async () => new Date();
+            "
+        `);
+    });
 });
 
 describe("emitSourceFile", () => {

--- a/packages/core/src/compiler/Compiler.ts
+++ b/packages/core/src/compiler/Compiler.ts
@@ -55,7 +55,10 @@ export class Compiler {
     }
 
     public getContext(target?: string): CompilationContext | undefined {
-        return this.contextMap.get(target ?? "*");
+        if (target) {
+            return this.contextMap.get(target);
+        }
+        return this.createCompilationContext(this.options, target, this.dependencyCallback);
     }
 
     public getSystem(): ts.System {
@@ -94,32 +97,21 @@ export class Compiler {
         this.createTargetContextsIfNecessary();
 
         const results: ts.EmitResult[] = [];
-        this.options.targets.forEach((target: string) => {
-            const result: ts.EmitResult = { diagnostics: [], emitSkipped: false, emittedFiles: [] };
-            const { config } = this.options;
-            const { writeFile = true } = getTargetConfig(target, config);
-            const ctx = this.contextMap.get(target);
-
-            if (!ctx) {
-                return;
+        if (!this.options.targets || !this.options.targets.length) {
+            const ctx = this.getContext();
+            if (ctx) {
+                const result = this.emitResult(undefined, ctx); // no target
+                results.push(this.options.transpileOnly ? result : this.report(ctx.getProgram(), result));
             }
-
-            for (const fileName of this.getRootFiles()) {
-                const fragment = this.emitSourceFile(fileName, target, writeFile);
-                if (fragment?.files.length > 0) {
-                    result.emittedFiles?.push(...fragment.files.map(cur => cur.name));
-                } else {
-                    fragment.diagnostics?.forEach(diagnostic => this.reporter.reportDiagnostic(diagnostic));
-                    result.diagnostics = [...result.diagnostics, ...(fragment.diagnostics ?? [])];
-                    result.emitSkipped = !!fragment.diagnostics && fragment.diagnostics.length > 0 ? true : false;
+        } else {
+            this.options.targets.forEach((target: string) => {
+                const ctx = this.getContext(target);
+                if (ctx) {
+                    const result = this.emitResult(target, ctx);
+                    results.push(this.options.transpileOnly ? result : this.report(ctx.getProgram(), result));
                 }
-            }
-
-            const files = this.getRootFiles();
-            ctx.getResultProcessors().forEach(cur => cur(files));
-
-            results.push(this.options.transpileOnly ? result : this.report(ctx.getProgram(), result));
-        });
+            });
+        }
 
         return results.filter(cur => !!cur).length < 1
             ? { emitSkipped: true, diagnostics: [] }
@@ -130,13 +122,34 @@ export class Compiler {
               };
     }
 
+    private emitResult(target: string | undefined, ctx: CompilationContext): ts.EmitResult {
+        const result: ts.EmitResult = { diagnostics: [], emitSkipped: false, emittedFiles: [] };
+        const { config } = this.options;
+        const { writeFile = true } = getTargetConfig(target, config);
+
+        for (const fileName of this.getRootFiles()) {
+            const fragment = this.emitSourceFile(fileName, target, writeFile);
+            if (fragment?.files.length > 0) {
+                result.emittedFiles?.push(...fragment.files.map(cur => cur.name));
+            } else {
+                fragment.diagnostics?.forEach(diagnostic => this.reporter.reportDiagnostic(diagnostic));
+                result.diagnostics = [...result.diagnostics, ...(fragment.diagnostics ?? [])];
+                result.emitSkipped = !!fragment.diagnostics && fragment.diagnostics.length > 0 ? true : false;
+            }
+        }
+
+        const files = this.getRootFiles();
+        ctx.getResultProcessors().forEach(cur => cur(files));
+        return result;
+    }
+
     public watch(): this {
         this.createTargetContextsIfNecessary();
 
         if (typeof this.system.watchFile === "function") {
             const emitTargets: string[] = this.getWritingTargets();
             this.getRootFiles().forEach(cur => {
-                if (this.options.targets[0] === "*") {
+                if (this.options?.targets?.[0] === "*") {
                     emitTargets.push("*");
                 }
                 emitTargets.forEach(target => this.emitSourceFile(cur, target, true));
@@ -185,27 +198,33 @@ export class Compiler {
     }
 
     protected createTargetContextsIfNecessary(): this {
-        this.options.targets.forEach((target: string) => {
-            if (this.contextMap.has(target)) {
-                return;
-            }
-
-            const ctx = this.createCompilationContext(this.options, target, this.dependencyCallback);
-            this.addons?.getAvailableAddons(target).forEach(addon => {
+        if (!this.options.targets || !this.options.targets.length) {
+            const ctx = this.createCompilationContext(this.options, undefined, this.dependencyCallback);
+            this.addons?.getAvailableAddons().forEach(addon => {
                 addon.activate(ctx);
             });
-            this.contextMap.set(target, ctx);
-        });
+        } else {
+            this.options.targets.forEach((target: string) => {
+                if (this.contextMap.has(target)) {
+                    return;
+                }
+                const ctx = this.createCompilationContext(this.options, target, this.dependencyCallback);
+                this.addons?.getAvailableAddons(target).forEach(addon => {
+                    addon.activate(ctx);
+                });
+                this.contextMap.set(target, ctx);
+            });
+        }
         return this;
     }
 
     protected createCompilationContext(
         compileOptions: CompilerOptions,
-        target: string,
+        target?: string,
         registerDependencyCallback?: (filePath: string) => void
     ): CompilationContext {
         const { buildDir, config, project, tsconfig, watch } = compileOptions;
-        const { options, config: targetConfig } = getTargetConfig(target, config);
+        const { options = {}, config: targetConfig } = getTargetConfig(target, config);
         return new CompilationContext({
             buildDir,
             project: { ...project, ...options },
@@ -215,16 +234,16 @@ export class Compiler {
             tsconfig: { ...tsconfig, options: { ...project, ...options } },
             rootFiles: this.getRootFiles(),
             reporter: this.reporter,
-            config: targetConfig,
+            ...(!!targetConfig && { config: targetConfig }),
             target,
             ...(watch && { watchCallback: (filePath: string) => this.registerWatch(filePath, this.getWritingTargets()) }),
             registerDependencyCallback,
         });
     }
 
-    protected emitSourceFile(fileName: string, target: string, writeFile = true, skipCache = false): CompileFragment {
+    protected emitSourceFile(fileName: string, target?: string, writeFile = true, skipCache = false): CompileFragment {
         const filePath = this.system.resolvePath(fileName);
-        const ctx = this.contextMap.get(target);
+        const ctx = this.getContext(target);
         const cache = ctx?.getCache();
 
         if (ctx && cache) {
@@ -252,11 +271,11 @@ export class Compiler {
     }
 
     protected getNonWritingTargets(): string[] {
-        return this.options.targets.filter(cur => !getTargetConfig(cur, this.options.config).writeFile);
+        return this.options.targets?.filter(cur => !getTargetConfig(cur, this.options.config).writeFile) ?? [];
     }
 
     protected getWritingTargets(): string[] {
-        return this.options.targets.filter(cur => getTargetConfig(cur, this.options.config).writeFile);
+        return this.options.targets?.filter(cur => getTargetConfig(cur, this.options.config).writeFile) ?? [];
     }
 
     private processOutput(
@@ -346,8 +365,8 @@ export class Compiler {
     }
 }
 
-const getTargetConfig = (target: string, config?: CompilationConfig): TargetConfig => {
-    if (config) {
+const getTargetConfig = (target?: string, config?: CompilationConfig): TargetConfig => {
+    if (config && target) {
         const { targets = {} } = config;
         return targets[target] ?? {};
     }

--- a/packages/core/src/compiler/CompilerOptions.ts
+++ b/packages/core/src/compiler/CompilerOptions.ts
@@ -20,7 +20,7 @@ export interface CompilerOptions {
      * List of targets to be compiled. Refers to the `targets` defined in the `config` property.
      * Use `["*"]` to compile with all available addons. No addons will be used if no target is specified.
      */
-    targets: string[];
+    targets?: string[];
     /**
      * Whether to only transpile the code without emitting any output.
      * Overrides the `transpileOnly` specified in the `tsconfig.json`.

--- a/packages/core/src/compiler/addons/AddonRegistry.spec.ts
+++ b/packages/core/src/compiler/addons/AddonRegistry.spec.ts
@@ -21,7 +21,7 @@ describe("Ctor", () => {
         reporter.reportDiagnostic = jest.fn();
         expect(system.directoryExists("./addons")).toBe(false);
 
-        new AddonRegistry({ addonsDir: "./addons", reporter, system }).refresh();
+        new AddonRegistry({ addonsDir: "./addons", reporter, system });
 
         expect(reporter.reportDiagnostic).toHaveBeenCalledWith(new WarnMessage('Addons directory "./addons" does not exist.'));
     });
@@ -46,7 +46,7 @@ describe("getAvailableAddons", () => {
     it("returns addons w/ single addon in addon directory", () => {
         createAddon("addons/expected/addon");
 
-        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system }).refresh();
+        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system });
 
         expect(testObj.getAvailableAddons("*").getNames()).toEqual(["expected"]);
     });
@@ -56,7 +56,7 @@ describe("getAvailableAddons", () => {
         createAddon("addons/two/addon");
         createAddon("addons/three/addon");
 
-        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system }).refresh();
+        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system });
 
         expect(testObj.getAvailableAddons("*").getNames()).toEqual(["one", "two", "three"]);
     });
@@ -65,7 +65,7 @@ describe("getAvailableAddons", () => {
         createAddon("addons/expected/addon");
         createAddon("addons/invalid/addon", "export const whatever = () => {};", { whatever: jest.fn() });
 
-        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system }).refresh();
+        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system });
 
         expect(testObj.getAvailableAddons("*").getNames()).toEqual(["expected"]);
     });
@@ -73,7 +73,7 @@ describe("getAvailableAddons", () => {
     it("returns no addons w/ empty files in addon directory", () => {
         createAddon("addons/empty/addon", "", {});
 
-        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system }).refresh();
+        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system });
 
         expect(testObj.getAvailableAddons("*")).toHaveLength(0);
     });
@@ -125,7 +125,7 @@ describe("refresh", () => {
     it("refreshes addons w/ new addons", () => {
         createAddon("addons/expected/addon");
 
-        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system }).refresh();
+        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system });
 
         expect(testObj.getAvailableAddons("*").getNames()).toEqual(["expected"]);
 
@@ -139,7 +139,7 @@ describe("refresh", () => {
     it("refreshes addons w/o new addons", () => {
         createAddon("addons/expected/addon");
 
-        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system }).refresh();
+        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system });
 
         expect(testObj.getAvailableAddons("*").getNames()).toEqual(["expected"]);
 
@@ -152,7 +152,7 @@ describe("refresh", () => {
         createAddon("addons/expected/addon");
         createAddon("addons/removed/addon");
 
-        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system }).refresh();
+        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system });
 
         expect(testObj.getAvailableAddons("*").getNames()).toEqual(["expected", "removed"]);
 
@@ -166,7 +166,7 @@ describe("refresh", () => {
     it("refreshes addons w/ empty addons directory", () => {
         createAddon("addons/expected/addon");
 
-        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system }).refresh();
+        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system });
 
         expect(testObj.getAvailableAddons("*").getNames()).toEqual(["expected"]);
 
@@ -248,7 +248,7 @@ describe("getMissingAddons", () => {
     it("returns missing addons w/ missing and available addons", () => {
         createAddon("target/expected/addon");
 
-        const testObj = new AddonRegistry({ addons: ["missing", "expected"], addonsDir: "./target", reporter, system }).refresh();
+        const testObj = new AddonRegistry({ addons: ["missing", "expected"], addonsDir: "./target", reporter, system });
 
         // @ts-expect-error private property access
         expect(testObj.getMissingAddons()).toEqual(["missing"]);
@@ -259,7 +259,7 @@ describe("reportMissingAddons", () => {
     it("reports missing addons directory", () => {
         reporter.reportDiagnostic = jest.fn();
 
-        const testObj = new AddonRegistry({ addonsDir: "./expected", reporter, system }).refresh();
+        const testObj = new AddonRegistry({ addonsDir: "./expected", reporter, system });
 
         // @ts-expect-error private property access
         testObj.reportMissingAddons(undefined, []);
@@ -281,7 +281,7 @@ describe("reportMissingAddons", () => {
         createAddon("target/expected/addon");
         reporter.reportDiagnostic = jest.fn();
 
-        new AddonRegistry({ addonsDir: "./target", addons: ["expected"], reporter, system }).refresh().getAvailableAddons("*");
+        new AddonRegistry({ addonsDir: "./target", addons: ["expected"], reporter, system }).getAvailableAddons("*");
 
         expect(reporter.reportDiagnostic).not.toHaveBeenCalled();
     });
@@ -310,9 +310,7 @@ describe("reportMissingAddons", () => {
             addonsDir: "./target",
             reporter,
             system,
-        })
-            .refresh()
-            .getAvailableAddons("target");
+        }).getAvailableAddons("target");
 
         expect(reporter.reportDiagnostic).not.toHaveBeenCalled();
     });
@@ -322,7 +320,7 @@ describe("findAddons", () => {
     it("finds addons w/ single addon in addons directory", () => {
         createAddon("addons/expected/addon");
 
-        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system }).refresh();
+        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system });
 
         expect(testObj.getAvailableAddons("*").getNames()).toEqual(["expected"]);
     });
@@ -332,7 +330,7 @@ describe("findAddons", () => {
         createAddon("addons/two/addon");
         createAddon("addons/three/addon");
 
-        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system }).refresh();
+        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system });
 
         expect(testObj.getAvailableAddons("*").getNames()).toEqual(["one", "two", "three"]);
     });
@@ -341,7 +339,7 @@ describe("findAddons", () => {
         createAddon("addons/expected/addon");
         createAddon("addons/invalid/addon", "export const whatever = () => {};", { whatever: jest.fn() });
 
-        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system }).refresh();
+        const testObj = new AddonRegistry({ addonsDir: "./addons", reporter, system });
 
         expect(testObj.getAvailableAddons("*").getNames()).toEqual(["expected"]);
     });

--- a/packages/core/src/compiler/addons/AddonRegistry.ts
+++ b/packages/core/src/compiler/addons/AddonRegistry.ts
@@ -22,8 +22,8 @@ export class AddonRegistry {
     private config: AddonConfig;
 
     constructor(config: AddonConfig) {
-        this.availableAddons = new Map<string, CompilerAddon>();
         this.config = { ...config };
+        this.availableAddons = this.findAddons();
     }
 
     setConfig(config: Partial<AddonConfig>): this {

--- a/packages/core/src/compiler/addons/AddonRegistry.ts
+++ b/packages/core/src/compiler/addons/AddonRegistry.ts
@@ -35,6 +35,17 @@ export class AddonRegistry {
         return this.config.addonsDir;
     }
 
+    /**
+     * Retrieves the available compiler addons based on the specified target. Only addons that are
+     * provided in the 'addonsDir' are requested. If unavailable addons are requested, a warning message
+     * is emitted to the registry's reporter.
+     *
+     * @param target - An optional string specifying the target for which to retrieve the addons.
+     *                 If not provided, the function will retrieve addons specified by the 'addons'
+     *                 property in the configuration, or an empty array.
+     * @returns A `CompilerAddons` object containing the available addons for the specified 'target'
+     *          or by the 'addons' property in the configuration.
+     */
     public getAvailableAddons(target?: string): CompilerAddons {
         this.reportMissingAddons(target);
         const expectedNames = this.getExpectedAddons(target);
@@ -50,6 +61,13 @@ export class AddonRegistry {
         return this;
     }
 
+    /**
+     * Retrieves the list of expected addons based on the provided 'target' and the 'addons'
+     * property from the configuration.
+     *
+     * @param target - An optional string representing the target for which to retrieve addons.
+     * @returns An array of unique addon names that are expected for the given target or 'addons' config.
+     */
     private getExpectedAddons(target?: string): string[] {
         const { targets = {}, addons = [] } = this.config;
         const requestedAddons = addons.filter(it => it.length > 0);

--- a/packages/core/src/compiler/compilation/CompilationContext.ts
+++ b/packages/core/src/compiler/compilation/CompilationContext.ts
@@ -20,7 +20,7 @@ export type CompilationContextOptions = {
     reporter: Reporter;
     rootFiles: string[];
     system: ts.System;
-    target: string;
+    target?: string;
     tsconfig: ts.ParsedCommandLine;
     watchCallback?: (filePath: string) => void;
     registerDependencyCallback?: (filePath: string) => void;
@@ -230,13 +230,14 @@ export class CompilationContext implements AddonContext {
     }: {
         system: ts.System;
         options: ts.CompilerOptions;
-        target: string;
+        target?: string;
     }): ts.LanguageServiceHost {
         return {
             ...createSharedHost(system),
             getScriptVersion: (fileName: string) => {
                 fileName = system.resolvePath(fileName);
-                return `${fileName}:${this.cache.getVersion(fileName).toString()}:${target}`;
+                const version = this.cache.getVersion(fileName).toString();
+                return target ? `${fileName}:${version}:${target}` : `${fileName}:${version}`;
             },
             getScriptSnapshot: (fileName: string) => {
                 fileName = system.resolvePath(fileName);

--- a/packages/core/src/compiler/config/resolve-targets.ts
+++ b/packages/core/src/compiler/config/resolve-targets.ts
@@ -10,11 +10,12 @@ import { CompilationConfig } from "./CompilationConfig";
 // TODO: Target resolution: Passed targets in CLI vs. specified targets in CompilationConfig
 //  Passed target this args.target
 //  Specified targets in CompilationConfig
-export const resolveTargets = (targets: string, config: CompilationConfig | undefined, reporter: Reporter) => {
-    const passedTargets = targets
-        .split(",")
-        .map(it => it.trim())
-        .filter(it => it.length > 0);
+export const resolveTargets = (targets: string | undefined, config: CompilationConfig | undefined, reporter: Reporter) => {
+    const passedTargets =
+        targets
+            ?.split(",")
+            .map(it => it.trim())
+            .filter(it => it.length > 0) ?? [];
     if (passedTargets.length > 0 && passedTargets[0] !== "*") {
         const configured = Object.keys(config?.targets ?? {});
         const missingTargets = passedTargets.filter(passed => configured[0] !== "*" && !configured.includes(passed));

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -30,7 +30,7 @@
         "build": "tsc",
         "watch": "tsc --watch",
         "watch:test": "jest --watch",
-        "test": "jest --coverage --passWithNoTests",
+        "test": "jest --coverage",
         "test:update-snapshots": "pnpm test -u",
         "dist": "pnpm clean && pnpm lint && pnpm test && cross-env-shell NODE_ENV=production \"pnpm build\""
     },

--- a/packages/testing/src/compilation/environment.ts
+++ b/packages/testing/src/compilation/environment.ts
@@ -142,7 +142,7 @@ export class CompilationEnv {
 
     // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
     public getActiveAddon(addonName: string): CompilerAddon | undefined {
-        return this.addons?.getAvailableAddons().find((it: CompilerAddon) => it.getName() === addonName);
+        return this.addons?.getAvailableAddons("*").find((it: CompilerAddon) => it.getName() === addonName);
     }
 
     public getActiveAddons(target?: string): CompilerAddons {

--- a/packages/testing/src/compilation/environment.ts
+++ b/packages/testing/src/compilation/environment.ts
@@ -36,7 +36,8 @@ export class CompilationEnv {
     private buildDir: string;
     private system: ts.System;
     private virtual: boolean;
-    private addons: AddonRegistry;
+    private addons?: AddonRegistry;
+    private addonsConfig: AddonConfig;
 
     constructor(rootDir?: string, options?: Partial<CompilationOptions>, addonConfig?: Partial<AddonConfig>) {
         const { virtual = true, compilerOptions = {}, useCaseSensitiveFileNames } = options ?? {};
@@ -74,15 +75,14 @@ export class CompilationEnv {
             ...compilerOptions,
         });
 
-        const registryConfig = {
+        this.addonsConfig = {
             addonsDir: join(this.rootDir, "./addons"),
             reporter: new DefaultReporter(this.system),
             system: this.system,
             ...(addonConfig ?? {}),
         };
-        this.addons = new AddonRegistry(registryConfig);
-        if (!this.system.directoryExists(this.addons.getAddonsDir())) {
-            this.system.createDirectory(this.addons.getAddonsDir());
+        if (!this.system.directoryExists(this.addonsConfig.addonsDir)) {
+            this.system.createDirectory(this.addonsConfig.addonsDir);
         }
     }
 
@@ -121,7 +121,7 @@ export class CompilationEnv {
                 directories = [this.buildDir, this.getOutDir()];
                 break;
             case "addons":
-                directories = [this.addons.getAddonsDir()];
+                directories = [this.addonsConfig.addonsDir];
                 break;
         }
         directories.forEach(dir =>
@@ -137,7 +137,7 @@ export class CompilationEnv {
      * @returns absolute path to the addons directory, defaults to `${this.rootDir}/addons`
      */
     public getAddonsDir(): string | undefined {
-        return this.addons?.getAddonsDir();
+        return this.addonsConfig.addonsDir;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
@@ -159,10 +159,7 @@ export class CompilationEnv {
      * @returns this instance
      */
     public addAddon(addonName: string, addonSource?: string | Record<string, string>): this {
-        if (!this.addons) {
-            return this;
-        }
-        const addonTargetPath = join(this.addons.getAddonsDir(), addonName);
+        const addonTargetPath = join(this.addonsConfig.addonsDir, addonName);
         let addonImportDir = join(this.rootDir, addonName);
 
         if (!this.system.directoryExists(addonTargetPath)) {
@@ -177,24 +174,22 @@ export class CompilationEnv {
             addonImportDir = addonsSourceDir;
         }
 
-        if (this.addons) {
-            this.compileAddons(addonImportDir, this.addons.getAddonsDir());
-            this.addons.refresh();
-        }
+        this.compileAddons(addonImportDir, this.addonsConfig.addonsDir);
+        this.getOrCreateAddonRegistry().refresh();
+
         return this;
     }
 
     public addAddons(addonNames: string[], addonsSourceDir?: string): this {
-        if (this.addons) {
-            const addonsDir = this.addons.getAddonsDir();
-            const addonsSourceDirPath = resolveProjectPath(this.system, this.rootDir, addonsSourceDir ?? DEFAULT_ADDONS_SOURCE_DIR);
-            const sourceFs = this.system.directoryExists(addonsSourceDirPath) ? this.system : ts.sys;
-            addonNames.forEach(addon => {
-                copyDirectory({ system: sourceFs, path: join(addonsSourceDirPath, addon), kind: "addons" }, { system: this.system, path: addonsDir });
-            });
-            this.compileAddons(addonsSourceDirPath, addonsDir);
-            this.addons?.refresh();
-        }
+        const addonsDir = this.addonsConfig.addonsDir;
+        const addonsSourceDirPath = resolveProjectPath(this.system, this.rootDir, addonsSourceDir ?? DEFAULT_ADDONS_SOURCE_DIR);
+        const sourceFs = this.system.directoryExists(addonsSourceDirPath) ? this.system : ts.sys;
+        addonNames.forEach(addon => {
+            copyDirectory({ system: sourceFs, path: join(addonsSourceDirPath, addon), kind: "addons" }, { system: this.system, path: addonsDir });
+        });
+        this.compileAddons(addonsSourceDirPath, addonsDir);
+        this.getOrCreateAddonRegistry().refresh();
+
         return this;
     }
 
@@ -255,7 +250,7 @@ export class CompilationEnv {
     }
 
     public compile(): this & CompilationResult {
-        const result = new Compiler(this.compilerOptions, this.system, this.addons).compile();
+        const result = new Compiler(this.compilerOptions, this.system, this.getOrCreateAddonRegistry()).compile();
         // @ts-expect-error - method is not part of the original object
         this.getDiagnostics = () => result.diagnostics;
         // @ts-expect-error - method is not part of the original object
@@ -295,16 +290,20 @@ export class CompilationEnv {
         return file ? projectFile(this.system, this.buildDir, file) : undefined;
     }
 
-    private resolveAddonSourcePaths(addonName: string, addonFiles: Record<string, string>, addonTargetPath: string): Record<string, string> {
+    private getOrCreateAddonRegistry(): AddonRegistry {
         if (!this.addons) {
-            return {};
+            this.addons = new AddonRegistry(this.addonsConfig);
         }
+        return this.addons;
+    }
+
+    private resolveAddonSourcePaths(addonName: string, addonFiles: Record<string, string>, addonTargetPath: string): Record<string, string> {
         return Object.entries(addonFiles).reduce((acc: Record<string, string>, [filePath, content]) => {
             if (isAbsolute(filePath)) {
                 acc[filePath] = content;
             } else {
                 if (filePath.includes(addonName)) {
-                    acc[join(this.addons.getAddonsDir(), filePath)] = content;
+                    acc[join(this.addonsConfig.addonsDir, filePath)] = content;
                 } else {
                     acc[join(addonTargetPath, filePath)] = content;
                 }
@@ -340,7 +339,7 @@ export class CompilationEnv {
 
         if (this.virtual) {
             this.system
-                .readDirectory(addonsTargetDir, [".js", ".jsx"])
+                .readDirectory(addonsTargetDir, [".js", ".jsx", ".ts", ".tsx"])
                 .map(filePath => this.system.resolvePath(filePath))
                 .forEach(resolvedPath => {
                     jest.mock(

--- a/packages/testing/src/compilation/environment.ts
+++ b/packages/testing/src/compilation/environment.ts
@@ -339,7 +339,7 @@ export class CompilationEnv {
 
         if (this.virtual) {
             this.system
-                .readDirectory(addonsTargetDir, [".js", ".jsx", ".ts", ".tsx"])
+                .readDirectory(addonsTargetDir, [".js", ".jsx"])
                 .map(filePath => this.system.resolvePath(filePath))
                 .forEach(resolvedPath => {
                     jest.mock(

--- a/packages/webpack/src/TsCompiler.ts
+++ b/packages/webpack/src/TsCompiler.ts
@@ -79,7 +79,7 @@ export class TsCompiler extends Compiler {
 
         const result = this.emitSourceFile(fileName, this.webpackTarget, false);
 
-        if (result.diagnostics && result.diagnostics.length > 0) {
+        if (result.diagnostics?.length) {
             result.diagnostics.forEach((diagnostic: ts.Diagnostic) => {
                 const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
                 this.pluginConfig?.error ? this.pluginConfig?.error(new WebpackError(message)) : console.error(message);
@@ -90,6 +90,12 @@ export class TsCompiler extends Compiler {
             .filter((target: string) => target !== this.webpackTarget)
             .forEach((target: string) => {
                 this.emitSourceFile(fileName, target, true);
+
+                // TODO: We cannot apply the resultProcessors to the resulting fragment, because webpack has not written the file yet.
+                this.contextMap
+                    .get(target)
+                    ?.getResultProcessors()
+                    .forEach(cur => cur([fileName]));
             });
 
         this.fragment = result;

--- a/packages/webpack/src/TsCompiler.ts
+++ b/packages/webpack/src/TsCompiler.ts
@@ -56,7 +56,7 @@ export class TsCompiler extends Compiler {
                       addonsDir: addonsDir ?? options.config?.addonsDir ?? "./addons",
                       reporter: options.reporter,
                       system,
-                  }).refresh()
+                  })
                 : undefined,
             dependencyCallback
         );

--- a/packages/webpack/src/TsCompiler.ts
+++ b/packages/webpack/src/TsCompiler.ts
@@ -27,7 +27,7 @@ export class TsCompiler extends Compiler {
                     .map(it => it.trim())
                     .filter(it => it.length > 0) ?? [],
             addonsDir: pluginOptions.addonsDir,
-            ...(pluginOptions.transpileOnly ? { transpileOnly: pluginOptions.transpileOnly } : {}),
+            ...(!!pluginOptions.transpileOnly && { transpileOnly: pluginOptions.transpileOnly }),
         };
         if (pluginOptions.config) {
             websmithConfig = { ...resolveCompilationConfig(pluginOptions.config, options.reporter, system), ...websmithConfig };
@@ -62,7 +62,7 @@ export class TsCompiler extends Compiler {
         );
         this.pluginConfig = pluginOptions;
         super.createTargetContextsIfNecessary();
-        this.targets = targetNames.length ? targetNames : options.targets;
+        this.targets = targetNames.length ? targetNames : options.targets ?? [];
         this.webpackTarget = this.getFragmentTarget(pluginOptions.webpackTarget!);
     }
 

--- a/packages/webpack/src/instance-cache.spec.ts
+++ b/packages/webpack/src/instance-cache.spec.ts
@@ -27,7 +27,6 @@ beforeEach(() => {
             buildDir: "./src",
             project: {},
             reporter,
-            targets: [],
             tsconfig: { options: { outDir: ".build" }, fileNames: [], errors: [] },
             debug: false,
             sourceMap: false,

--- a/packages/webpack/src/loader-options.ts
+++ b/packages/webpack/src/loader-options.ts
@@ -31,8 +31,8 @@ export const getLoaderOptions = (loader: LoaderContext<PluginOptions>): PluginOp
     const options: PluginOptions = loader.getOptions();
     const result = {
         ...options,
-        ...(loader._module && loader._module.addWarning && { warn: (err: WebpackError) => loader._module!.addWarning(err) }),
-        ...(loader._module && loader._module.addError && { error: (err: WebpackError) => loader._module!.addError(err) }),
+        ...(!!loader._module && typeof loader._module.addWarning === "function" && { warn: (err: WebpackError) => loader._module!.addWarning(err) }),
+        ...(!!loader._module && typeof loader._module.addError === "function" && { error: (err: WebpackError) => loader._module!.addError(err) }),
         config: uPath.resolve(options.config ?? DEFAULTS.config),
         transpileOnly: options.transpileOnly ?? false,
         webpackTarget: options.webpackTarget ?? "*",

--- a/packages/webpack/src/options.spec.ts
+++ b/packages/webpack/src/options.spec.ts
@@ -49,7 +49,7 @@ describe("createOptions", () => {
             { virtual: true }
         );
 
-        const actual = addons.refresh().getAvailableAddons();
+        const actual = addons.getAvailableAddons("*");
 
         expect(actual.map(it => it.getName())).toEqual(["addon-foo"]);
     });
@@ -80,10 +80,10 @@ describe("createOptions", () => {
     });
 
     it("should return config w/ valid addonsDir, addons in compiler config json", () => {
-        const { addons } = compileSystem({
+        const { fileSystem: target } = compileSystem({
             files: {
-                "./tsconfig.json": "{}",
-                "/expected/one/addon.js": "export const activate = () => {};",
+                "./tsconfig.json": '{ "include": ["**/*.ts"] }',
+                "/expected/one/addon.ts": "export const activate = () => {};",
                 "websmith.config.json": '{ "addons":["one", "two"], "addonsDir":"./expected" }',
             },
         });
@@ -95,20 +95,31 @@ describe("createOptions", () => {
             { virtual: true }
         );
 
-        const actual = addons.refresh();
+        const actual = createOptions({ config: "./websmith.config.json" }, new NoReporter(), target);
 
         expect(actual).toMatchObject({
-            availableAddons: new Map(
-                Object.entries({
-                    one: {
-                        activate: expect.any(Function),
-                        getName: expect.any(Function),
-                    },
-                })
-            ),
+            buildDir: "/",
             config: {
                 addons: ["one", "two"],
-                addonsDir: "./expected",
+                addonsDir: "/expected",
+                configFilePath: "/websmith.config.json",
+            },
+            project: {
+                configFilePath: "/tsconfig.json",
+                outDir: "/lib",
+            },
+
+            targets: ["*"],
+            tsconfig: {
+                fileNames: ["/expected/one/addon.ts"],
+                errors: [],
+                options: {
+                    configFilePath: "/tsconfig.json",
+                    outDir: "/lib",
+                },
+                raw: {
+                    include: ["**/*.ts"],
+                },
             },
         });
     });

--- a/packages/webpack/src/result-handling.ts
+++ b/packages/webpack/src/result-handling.ts
@@ -13,7 +13,7 @@ import { PluginOptions } from "./loader-options";
 export const makeSourceMap = (outputText: string, sourceMapText?: string) => {
     return {
         output: outputText.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, ""),
-        ...(sourceMapText && { sourceMap: JSON.parse(sourceMapText) }),
+        ...(!!sourceMapText && { sourceMap: JSON.parse(sourceMapText) }),
     };
 };
 


### PR DESCRIPTION
This PR improves the handling and testing of AddonRegistry. The most important changes include removing the `refresh` method from `AddonRegistry` instantiation, updating test cases to reflect this change, and modifying the `CompilationEnv` class to adapt to these updates.

### Production Code Changes:
* Removed the `refresh` method call from the `AddonRegistry` constructor and initialized `availableAddons` directly within the constructor.
* Updated the `CompilationEnv` class in `packages/testing/src/compilation/environment.ts` to use the new addon configuration handling, including changes to addon directory creation and retrieval.

### Test Case Changes:
* Updated various test cases in `packages/compiler/src/command.spec.ts` to remove calls to `addons.refresh()` and directly use `addons.getAvailableAddons("*")` instead. 
* Modified test cases in `packages/compiler/src/options.spec.ts` to align with the new addon handling mechanism, including changes to the `createOptions` function and configuration structure. 
* Adjusted tests in `packages/core/src/compiler/addons/AddonRegistry.spec.ts` to remove `refresh` method calls and directly instantiate `AddonRegistry` with the necessary configuration. 

### Miscellaneous:
* Modified the `test` script in `packages/testing/package.json` to remove the `--passWithNoTests` flag.