### PR TITLE
49 running the compiler w available addons but wo target does not transpile any output

### DIFF
--- a/packages/compiler/src/command.spec.ts
+++ b/packages/compiler/src/command.spec.ts
@@ -97,7 +97,7 @@ describe("addCompileCommand", () => {
         });
         expect(actual.reporter).toBeDefined();
         expect(actual.sourceMap).toBe(false);
-        expect(actual.targets).toEqual(["*"]);
+        expect(actual.targets).toEqual([]);
         expect(actual.watch).toBe(false);
     });
 

--- a/packages/compiler/src/command.ts
+++ b/packages/compiler/src/command.ts
@@ -53,7 +53,7 @@ export const addCompileCommand = (parent = program, compiler?: Compiler): Comman
             if (unknownArgs?.length > 0) {
                 options.additionalArguments = parseUnknownArguments(unknownArgs);
             }
-            if (hasInvalidTargets(options.targets, options.config)) {
+            if (options.targets && hasInvalidTargets(options.targets, options.config)) {
                 reporter.reportDiagnostic(
                     new WarnMessage(
                         `Custom target configuration "${options.targets.join(", ")}" found, but no target provided.\n` +
@@ -98,7 +98,7 @@ const addonConfig = (command: Command, compilationConfig?: CompilationConfig, op
     addonsDir:
         command.opts().addonsDir && command.opts().addonsDir !== "./addons" ? command.opts().addonsDir : compilationConfig?.addonsDir ?? "./addons",
 
-    targets: options?.config?.targets,
+    ...(!!options?.config?.targets && { targets: options?.config?.targets }),
 });
 
 export const hasInvalidTargets = (targets?: string[], config?: CompilationConfig) => {

--- a/packages/compiler/src/options.spec.ts
+++ b/packages/compiler/src/options.spec.ts
@@ -16,7 +16,6 @@ describe("createOptions", () => {
             expect.objectContaining({
                 debug: false,
                 sourceMap: false,
-                targets: ["*"],
                 watch: false,
             })
         );
@@ -119,7 +118,6 @@ describe("createOptions", () => {
                 outDir: "/lib",
             },
 
-            targets: ["*"],
             tsconfig: {
                 fileNames: ["/expected/one/addon.ts"],
                 errors: [],

--- a/packages/compiler/src/options.ts
+++ b/packages/compiler/src/options.ts
@@ -22,7 +22,6 @@ const DEFAULTS = {
     outDir: "./lib",
     project: "./tsconfig.json",
     sourceMap: false,
-    targets: "*",
     watch: false,
 };
 
@@ -55,7 +54,7 @@ export const createOptions = (args: CompilerArguments, reporter = new NoReporter
         project: tsconfig.options,
         reporter,
         sourceMap: args.sourceMap ?? DEFAULTS.sourceMap,
-        targets: resolveTargets(args.targets || DEFAULTS.targets, compilationConfig, reporter),
+        targets: resolveTargets(args.targets, compilationConfig, reporter),
         transpileOnly: args.transpileOnly ?? compilationConfig?.transpileOnly ?? false,
         watch: args.watch ?? DEFAULTS.watch,
     };

--- a/packages/core/src/compiler/Compiler.spec.ts
+++ b/packages/core/src/compiler/Compiler.spec.ts
@@ -167,6 +167,41 @@ describe("compile", () => {
             "
         `);
     });
+
+    it("yields output w/ with addons but w/o targets", () => {
+        const { fileSystem } = compileSystem({
+            "src/target.ts": `
+                export const computeDate = async (): Promise<Date> => new Date();
+            `,
+        });
+
+        new CompilerTestClass(
+            {
+                buildDir: "./src",
+                reporter: new ReporterMock(fileSystem),
+                debug: false,
+                sourceMap: false,
+                transpileOnly: false,
+                watch: false,
+                project: {
+                    module: ts.ModuleKind.ESNext,
+                    target: ts.ScriptTarget.Latest,
+                    configFilePath: "./tsconfig.json",
+                },
+                tsconfig: {
+                    options: {},
+                    fileNames: fileSystem.readDirectory("./src"),
+                    errors: [],
+                },
+            },
+            fileSystem
+        ).compile();
+
+        expect(fileSystem.readFile("/src/target.js")).toMatchInlineSnapshot(`
+            "export const computeDate = async () => new Date();
+            "
+        `);
+    });
 });
 
 describe("emitSourceFile", () => {

--- a/packages/core/src/compiler/Compiler.ts
+++ b/packages/core/src/compiler/Compiler.ts
@@ -55,7 +55,10 @@ export class Compiler {
     }
 
     public getContext(target?: string): CompilationContext | undefined {
-        return this.contextMap.get(target ?? "*");
+        if (target) {
+            return this.contextMap.get(target);
+        }
+        return this.createCompilationContext(this.options, target, this.dependencyCallback);
     }
 
     public getSystem(): ts.System {
@@ -94,32 +97,21 @@ export class Compiler {
         this.createTargetContextsIfNecessary();
 
         const results: ts.EmitResult[] = [];
-        this.options.targets.forEach((target: string) => {
-            const result: ts.EmitResult = { diagnostics: [], emitSkipped: false, emittedFiles: [] };
-            const { config } = this.options;
-            const { writeFile = true } = getTargetConfig(target, config);
-            const ctx = this.contextMap.get(target);
-
-            if (!ctx) {
-                return;
+        if (!this.options.targets || !this.options.targets.length) {
+            const ctx = this.getContext();
+            if (ctx) {
+                const result = this.emitResult(undefined, ctx); // no target
+                results.push(this.options.transpileOnly ? result : this.report(ctx.getProgram(), result));
             }
-
-            for (const fileName of this.getRootFiles()) {
-                const fragment = this.emitSourceFile(fileName, target, writeFile);
-                if (fragment?.files.length > 0) {
-                    result.emittedFiles?.push(...fragment.files.map(cur => cur.name));
-                } else {
-                    fragment.diagnostics?.forEach(diagnostic => this.reporter.reportDiagnostic(diagnostic));
-                    result.diagnostics = [...result.diagnostics, ...(fragment.diagnostics ?? [])];
-                    result.emitSkipped = !!fragment.diagnostics && fragment.diagnostics.length > 0 ? true : false;
+        } else {
+            this.options.targets.forEach((target: string) => {
+                const ctx = this.getContext(target);
+                if (ctx) {
+                    const result = this.emitResult(target, ctx);
+                    results.push(this.options.transpileOnly ? result : this.report(ctx.getProgram(), result));
                 }
-            }
-
-            const files = this.getRootFiles();
-            ctx.getResultProcessors().forEach(cur => cur(files));
-
-            results.push(this.options.transpileOnly ? result : this.report(ctx.getProgram(), result));
-        });
+            });
+        }
 
         return results.filter(cur => !!cur).length < 1
             ? { emitSkipped: true, diagnostics: [] }
@@ -130,13 +122,34 @@ export class Compiler {
               };
     }
 
+    private emitResult(target: string | undefined, ctx: CompilationContext): ts.EmitResult {
+        const result: ts.EmitResult = { diagnostics: [], emitSkipped: false, emittedFiles: [] };
+        const { config } = this.options;
+        const { writeFile = true } = getTargetConfig(target, config);
+
+        for (const fileName of this.getRootFiles()) {
+            const fragment = this.emitSourceFile(fileName, target, writeFile);
+            if (fragment?.files.length > 0) {
+                result.emittedFiles?.push(...fragment.files.map(cur => cur.name));
+            } else {
+                fragment.diagnostics?.forEach(diagnostic => this.reporter.reportDiagnostic(diagnostic));
+                result.diagnostics = [...result.diagnostics, ...(fragment.diagnostics ?? [])];
+                result.emitSkipped = !!fragment.diagnostics && fragment.diagnostics.length > 0 ? true : false;
+            }
+        }
+
+        const files = this.getRootFiles();
+        ctx.getResultProcessors().forEach(cur => cur(files));
+        return result;
+    }
+
     public watch(): this {
         this.createTargetContextsIfNecessary();
 
         if (typeof this.system.watchFile === "function") {
             const emitTargets: string[] = this.getWritingTargets();
             this.getRootFiles().forEach(cur => {
-                if (this.options.targets[0] === "*") {
+                if (this.options?.targets?.[0] === "*") {
                     emitTargets.push("*");
                 }
                 emitTargets.forEach(target => this.emitSourceFile(cur, target, true));
@@ -185,27 +198,33 @@ export class Compiler {
     }
 
     protected createTargetContextsIfNecessary(): this {
-        this.options.targets.forEach((target: string) => {
-            if (this.contextMap.has(target)) {
-                return;
-            }
-
-            const ctx = this.createCompilationContext(this.options, target, this.dependencyCallback);
-            this.addons?.getAvailableAddons(target).forEach(addon => {
+        if (!this.options.targets || !this.options.targets.length) {
+            const ctx = this.createCompilationContext(this.options, undefined, this.dependencyCallback);
+            this.addons?.getAvailableAddons().forEach(addon => {
                 addon.activate(ctx);
             });
-            this.contextMap.set(target, ctx);
-        });
+        } else {
+            this.options.targets.forEach((target: string) => {
+                if (this.contextMap.has(target)) {
+                    return;
+                }
+                const ctx = this.createCompilationContext(this.options, target, this.dependencyCallback);
+                this.addons?.getAvailableAddons(target).forEach(addon => {
+                    addon.activate(ctx);
+                });
+                this.contextMap.set(target, ctx);
+            });
+        }
         return this;
     }
 
     protected createCompilationContext(
         compileOptions: CompilerOptions,
-        target: string,
+        target?: string,
         registerDependencyCallback?: (filePath: string) => void
     ): CompilationContext {
         const { buildDir, config, project, tsconfig, watch } = compileOptions;
-        const { options, config: targetConfig } = getTargetConfig(target, config);
+        const { options = {}, config: targetConfig } = getTargetConfig(target, config);
         return new CompilationContext({
             buildDir,
             project: { ...project, ...options },
@@ -215,16 +234,16 @@ export class Compiler {
             tsconfig: { ...tsconfig, options: { ...project, ...options } },
             rootFiles: this.getRootFiles(),
             reporter: this.reporter,
-            config: targetConfig,
+            ...(!!targetConfig && { config: targetConfig }),
             target,
             ...(watch && { watchCallback: (filePath: string) => this.registerWatch(filePath, this.getWritingTargets()) }),
             registerDependencyCallback,
         });
     }
 
-    protected emitSourceFile(fileName: string, target: string, writeFile = true, skipCache = false): CompileFragment {
+    protected emitSourceFile(fileName: string, target?: string, writeFile = true, skipCache = false): CompileFragment {
         const filePath = this.system.resolvePath(fileName);
-        const ctx = this.contextMap.get(target);
+        const ctx = this.getContext(target);
         const cache = ctx?.getCache();
 
         if (ctx && cache) {
@@ -252,11 +271,11 @@ export class Compiler {
     }
 
     protected getNonWritingTargets(): string[] {
-        return this.options.targets.filter(cur => !getTargetConfig(cur, this.options.config).writeFile);
+        return this.options.targets?.filter(cur => !getTargetConfig(cur, this.options.config).writeFile) ?? [];
     }
 
     protected getWritingTargets(): string[] {
-        return this.options.targets.filter(cur => getTargetConfig(cur, this.options.config).writeFile);
+        return this.options.targets?.filter(cur => getTargetConfig(cur, this.options.config).writeFile) ?? [];
     }
 
     private processOutput(
@@ -346,8 +365,8 @@ export class Compiler {
     }
 }
 
-const getTargetConfig = (target: string, config?: CompilationConfig): TargetConfig => {
-    if (config) {
+const getTargetConfig = (target?: string, config?: CompilationConfig): TargetConfig => {
+    if (config && target) {
         const { targets = {} } = config;
         return targets[target] ?? {};
     }

--- a/packages/core/src/compiler/CompilerOptions.ts
+++ b/packages/core/src/compiler/CompilerOptions.ts
@@ -20,7 +20,7 @@ export interface CompilerOptions {
      * List of targets to be compiled. Refers to the `targets` defined in the `config` property.
      * Use `["*"]` to compile with all available addons. No addons will be used if no target is specified.
      */
-    targets: string[];
+    targets?: string[];
     /**
      * Whether to only transpile the code without emitting any output.
      * Overrides the `transpileOnly` specified in the `tsconfig.json`.

--- a/packages/core/src/compiler/addons/AddonRegistry.ts
+++ b/packages/core/src/compiler/addons/AddonRegistry.ts
@@ -35,6 +35,17 @@ export class AddonRegistry {
         return this.config.addonsDir;
     }
 
+    /**
+     * Retrieves the available compiler addons based on the specified target. Only addons that are
+     * provided in the 'addonsDir' are requested. If unavailable addons are requested, a warning message
+     * is emitted to the registry's reporter.
+     *
+     * @param target - An optional string specifying the target for which to retrieve the addons.
+     *                 If not provided, the function will retrieve addons specified by the 'addons'
+     *                 property in the configuration, or an empty array.
+     * @returns A `CompilerAddons` object containing the available addons for the specified 'target'
+     *          or by the 'addons' property in the configuration.
+     */
     public getAvailableAddons(target?: string): CompilerAddons {
         this.reportMissingAddons(target);
         const expectedNames = this.getExpectedAddons(target);
@@ -50,6 +61,13 @@ export class AddonRegistry {
         return this;
     }
 
+    /**
+     * Retrieves the list of expected addons based on the provided 'target' and the 'addons'
+     * property from the configuration.
+     *
+     * @param target - An optional string representing the target for which to retrieve addons.
+     * @returns An array of unique addon names that are expected for the given target or 'addons' config.
+     */
     private getExpectedAddons(target?: string): string[] {
         const { targets = {}, addons = [] } = this.config;
         const requestedAddons = addons.filter(it => it.length > 0);

--- a/packages/core/src/compiler/compilation/CompilationContext.ts
+++ b/packages/core/src/compiler/compilation/CompilationContext.ts
@@ -20,7 +20,7 @@ export type CompilationContextOptions = {
     reporter: Reporter;
     rootFiles: string[];
     system: ts.System;
-    target: string;
+    target?: string;
     tsconfig: ts.ParsedCommandLine;
     watchCallback?: (filePath: string) => void;
     registerDependencyCallback?: (filePath: string) => void;
@@ -230,13 +230,14 @@ export class CompilationContext implements AddonContext {
     }: {
         system: ts.System;
         options: ts.CompilerOptions;
-        target: string;
+        target?: string;
     }): ts.LanguageServiceHost {
         return {
             ...createSharedHost(system),
             getScriptVersion: (fileName: string) => {
                 fileName = system.resolvePath(fileName);
-                return `${fileName}:${this.cache.getVersion(fileName).toString()}:${target}`;
+                const version = this.cache.getVersion(fileName).toString();
+                return target ? `${fileName}:${version}:${target}` : `${fileName}:${version}`;
             },
             getScriptSnapshot: (fileName: string) => {
                 fileName = system.resolvePath(fileName);

--- a/packages/core/src/compiler/config/resolve-targets.ts
+++ b/packages/core/src/compiler/config/resolve-targets.ts
@@ -10,11 +10,12 @@ import { CompilationConfig } from "./CompilationConfig";
 // TODO: Target resolution: Passed targets in CLI vs. specified targets in CompilationConfig
 //  Passed target this args.target
 //  Specified targets in CompilationConfig
-export const resolveTargets = (targets: string, config: CompilationConfig | undefined, reporter: Reporter) => {
-    const passedTargets = targets
-        .split(",")
-        .map(it => it.trim())
-        .filter(it => it.length > 0);
+export const resolveTargets = (targets: string | undefined, config: CompilationConfig | undefined, reporter: Reporter) => {
+    const passedTargets =
+        targets
+            ?.split(",")
+            .map(it => it.trim())
+            .filter(it => it.length > 0) ?? [];
     if (passedTargets.length > 0 && passedTargets[0] !== "*") {
         const configured = Object.keys(config?.targets ?? {});
         const missingTargets = passedTargets.filter(passed => configured[0] !== "*" && !configured.includes(passed));

--- a/packages/webpack/src/TsCompiler.ts
+++ b/packages/webpack/src/TsCompiler.ts
@@ -27,7 +27,7 @@ export class TsCompiler extends Compiler {
                     .map(it => it.trim())
                     .filter(it => it.length > 0) ?? [],
             addonsDir: pluginOptions.addonsDir,
-            ...(pluginOptions.transpileOnly ? { transpileOnly: pluginOptions.transpileOnly } : {}),
+            ...(!!pluginOptions.transpileOnly && { transpileOnly: pluginOptions.transpileOnly }),
         };
         if (pluginOptions.config) {
             websmithConfig = { ...resolveCompilationConfig(pluginOptions.config, options.reporter, system), ...websmithConfig };
@@ -62,7 +62,7 @@ export class TsCompiler extends Compiler {
         );
         this.pluginConfig = pluginOptions;
         super.createTargetContextsIfNecessary();
-        this.targets = targetNames.length ? targetNames : options.targets;
+        this.targets = targetNames.length ? targetNames : options.targets ?? [];
         this.webpackTarget = this.getFragmentTarget(pluginOptions.webpackTarget!);
     }
 

--- a/packages/webpack/src/instance-cache.spec.ts
+++ b/packages/webpack/src/instance-cache.spec.ts
@@ -27,7 +27,6 @@ beforeEach(() => {
             buildDir: "./src",
             project: {},
             reporter,
-            targets: [],
             tsconfig: { options: { outDir: ".build" }, fileNames: [], errors: [] },
             debug: false,
             sourceMap: false,

--- a/packages/webpack/src/loader-options.ts
+++ b/packages/webpack/src/loader-options.ts
@@ -31,8 +31,8 @@ export const getLoaderOptions = (loader: LoaderContext<PluginOptions>): PluginOp
     const options: PluginOptions = loader.getOptions();
     const result = {
         ...options,
-        ...(loader._module && loader._module.addWarning && { warn: (err: WebpackError) => loader._module!.addWarning(err) }),
-        ...(loader._module && loader._module.addError && { error: (err: WebpackError) => loader._module!.addError(err) }),
+        ...(!!loader._module && typeof loader._module.addWarning === "function" && { warn: (err: WebpackError) => loader._module!.addWarning(err) }),
+        ...(!!loader._module && typeof loader._module.addError === "function" && { error: (err: WebpackError) => loader._module!.addError(err) }),
         config: uPath.resolve(options.config ?? DEFAULTS.config),
         transpileOnly: options.transpileOnly ?? false,
         webpackTarget: options.webpackTarget ?? "*",

--- a/packages/webpack/src/result-handling.ts
+++ b/packages/webpack/src/result-handling.ts
@@ -13,7 +13,7 @@ import { PluginOptions } from "./loader-options";
 export const makeSourceMap = (outputText: string, sourceMapText?: string) => {
     return {
         output: outputText.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, ""),
-        ...(sourceMapText && { sourceMap: JSON.parse(sourceMapText) }),
+        ...(!!sourceMapText && { sourceMap: JSON.parse(sourceMapText) }),
     };
 };
 


### PR DESCRIPTION
This PR fixes issue #49. It focuses on refining the handling of compilation targets within the compiler and its related modules. The changes ensure that the compiler can function correctly even when no targets are specified.

Key changes include:

### Compiler Enhancements:
* Modified `getContext` and `emitResult` methods in `Compiler` class to handle cases where no targets are specified. 
* Updated the `createTargetContextsIfNecessary` method to create a compilation context when no targets are provided.

### Code Simplification:
* Refactored multiple conditional assignments to use more concise syntax. 
* Changed the `targets` property in `CompilerOptions` and `CompilationContext` to be optional. 

### Test Adjustments:
* Updated test cases to reflect the new behavior of handling empty targets. 

These changes improve the flexibility and robustness of the compiler, ensuring it can handle scenarios with and without specified targets more effectively.