### PR TITLE
B Stories default compilation-context in ContextMap to apply the same…

### DIFF
--- a/packages/core/src/compiler/Compiler.ts
+++ b/packages/core/src/compiler/Compiler.ts
@@ -58,7 +58,11 @@ export class Compiler {
         if (target) {
             return this.contextMap.get(target);
         }
-        return this.createCompilationContext(this.options, target, this.dependencyCallback);
+        const defaultCtx = this.contextMap.get("default");
+        if (!defaultCtx) {
+            this.contextMap.set("default", this.createCompilationContext(this.options, undefined, this.dependencyCallback));
+        }
+        return this.contextMap.get("default");
     }
 
     public getSystem(): ts.System {
@@ -199,7 +203,7 @@ export class Compiler {
 
     protected createTargetContextsIfNecessary(): this {
         if (!this.options.targets || !this.options.targets.length) {
-            const ctx = this.createCompilationContext(this.options, undefined, this.dependencyCallback);
+            const ctx = this.getContext()!;
             this.addons?.getAvailableAddons().forEach(addon => {
                 addon.activate(ctx);
             });


### PR DESCRIPTION
This PR focusses on improving the handling of compilation contexts by introducing a default context and refactoring the creation of target contexts.

Improvements to context handling:

* Modified the `getContext` method to use a default context if no specific target is provided. This ensures that a default compilation context is created and reused if it does not already exist.
* Refactored the `createTargetContextsIfNecessary` method to use the `getContext` method instead of directly creating a compilation context. This change leverages the new default context handling logic.… context in addons and the actual compilation.

Fixes #51