### PR TITLE
R: replace crypto-js sha256 with node:crypto's builtin sha256 #56

### DIFF
--- a/packages/compiler-test/jest.config.ts
+++ b/packages/compiler-test/jest.config.ts
@@ -16,6 +16,7 @@ const config: Config = {
         "@quatico/websmith-node": "<rootDir>/../node/src",
     },
     testRegex: "tests/.*(test|spec)\\.(js|ts)$",
+    testTimeout: 60000,
 };
 
 export default config;

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -34,15 +34,13 @@
     },
     "dependencies": {
         "@quatico/websmith-api": "workspace:*",
-        "@quatico/websmith-core": "workspace:*",
-        "crypto-js": "^4.2.0"
+        "@quatico/websmith-core": "workspace:*"
     },
     "devDependencies": {
         "@eslint/compat": "^1.2.6",
         "@eslint/js": "^9.19.0",
         "@nx/eslint-plugin": "^18.3.4",
         "@quatico/websmith-testing": "workspace:*",
-        "@types/crypto-js": "^4.2.2",
         "@types/jest": "^29.5.14",
         "@types/node": "20",
         "@types/webpack": "^5.28.5",

--- a/packages/webpack/src/loader-options.ts
+++ b/packages/webpack/src/loader-options.ts
@@ -5,7 +5,7 @@
  * ---------------------------------------------------------------------------------------------
  */
 
-import crypto from "crypto-js";
+import { createHash } from "node:crypto";
 import { type LoaderContext } from "webpack";
 import { createOptions } from "./options";
 import { type WebsmithLoaderConfig } from "./WebsmithLoaderConfig";
@@ -66,16 +66,16 @@ const resolveLoaderOptions = (
 };
 
 export const getOptionsHash = (options: WebsmithLoaderConfig) => {
-    const hash = crypto.algo.SHA256.create();
+    const hash = createHash("sha256");
     Object.keys(options).forEach(key => {
         const value = options[key as keyof WebsmithLoaderOptions];
         if (value !== undefined) {
             // eslint-disable-next-line @typescript-eslint/no-base-to-string
             const valueString = isFunction(value) ? value.toString() : JSON.stringify(value);
-            hash.update(crypto.enc.Utf8.parse(key + valueString));
+            hash.update(key + valueString, "utf-8");
         }
     });
-    return hash.finalize().toString(crypto.enc.Hex);
+    return hash.digest("hex");
 };
 
 const isFunction = (value: unknown): value is object => typeof value === "function";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -780,9 +780,6 @@ importers:
       '@quatico/websmith-core':
         specifier: workspace:*
         version: link:../core
-      crypto-js:
-        specifier: ^4.2.0
-        version: 4.2.0
     devDependencies:
       '@eslint/compat':
         specifier: ^1.2.6
@@ -796,9 +793,6 @@ importers:
       '@quatico/websmith-testing':
         specifier: workspace:*
         version: link:../testing
-      '@types/crypto-js':
-        specifier: ^4.2.2
-        version: 4.2.2
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -2061,9 +2055,6 @@ packages:
   '@types/cross-spawn@6.0.6':
     resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
-  '@types/crypto-js@4.2.2':
-    resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
-
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -2785,9 +2776,6 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  crypto-js@4.2.0:
-    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -6371,8 +6359,6 @@ snapshots:
     dependencies:
       '@types/node': 20.12.8
 
-  '@types/crypto-js@4.2.2': {}
-
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -7270,8 +7256,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  crypto-js@4.2.0: {}
 
   csstype@3.1.3: {}
 


### PR DESCRIPTION
This PR replaces `crypto-js` (as it is discontinued, see here: https://www.npmjs.com/package/crypto-js#discontinued) with Node's builtin crypto library. 

@jwloka I'm not 100% sure but I assumed that anyone wanting to use the package `webpack` would always use Node. We don't care about any Deno, Bun, etc. interop at the moment. 

Also, we didn't want this package to work in a browser environment (i.e. without Node), as the `crypto-js` library already relied on Node being available. 