### PR TITLE
Documentation updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Quatico Solutions Inc.
+Copyright (c) 2025 Quatico Solutions Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,29 +8,34 @@
 
 [![CI](https://github.com/quatico-solutions/websmith/actions/workflows/protect-stable.yml/badge.svg)](https://github.com/quatico-solutions/websmith/actions/workflows/protect-stable.yml)  [![npm version](https://badge.fury.io/js/@quatico%2Fwebsmith-compiler.svg)](https://www.npmjs.com/search?q=%40quatico)
 
-This project is a compiler frontend for the [TypeScript compiler](https://github.com/microsoft/TypeScript). It's a drop-in replacement for the `tsc` command and provides additional API for customizing the compilation process with addons. Provide your own compiler addons to modify the compilation input "before" the actual compilation process, during the compilation process or "after" compiled artifacts are created. An addon can
+This project is a compiler frontend for the [TypeScript compiler](https://github.com/microsoft/TypeScript). It's a drop-in replacement for the `tsc` command with additional customization options for the compilation process. You can apply compiler addons to modify the compilation input "before", during and "after" compiled artifacts are created. Even non-script files can be processed during the compilation process. Use the `websmith` command with an addon:
 
-* consume the unmodified source files to generate additional information based on the original source code,
-* create additional new input files and add them to the compilation process, or
-* modify input files to change module dependencies and modify imports/exports.
+* To generate additional configuration or documentation based on the original source code,
+* To create additional new source files and add them to the compilation process, or
+* To change module dependencies with new or modified imports/exports.
 
-Compiler addons can also access all transpiled files as whole and reason about the entire compilation target. The standard API for TypeScript transformers is fully integrated, thus existing `ts.CustomTransformers` can be simply called from within every addon.
+Compiler addons can also access all transpiled files as whole and reason about the entire compilation target. The standard API for TypeScript transformers is fully integrated, thus existing `ts.CustomTransformers` can be simply called from within an addon.
 
 ## Getting started
 
+Whenever you use the `tsc` command to compile your TypeScript project, you can replace it with the `websmith` command to apply compiler addons.
+
 ### Installation
 
-Install the following packages to add websmith to your TypeScript project. For example, execute the following command in your command line environment using `pnpm`:
+Add websmith to your TypeScript project with the `@quatico/websmith-compiler` package. For example, use the following command with `pnpm`:
 
 ```bash
-pnpm add typescript @quatico/websmith-compiler @quatico/websmith-api --dev
+pnpm add --dev @quatico/websmith-compiler
 ```
 
-### Add websmith to package.json
+If you don't have added the "typescript" dependency yet, add it to your project too.
+
+### Use websmith in your package.json
 
 In your package.json, add the `websmith` command as your build target to the `scripts` section:
 
  ```json
+// ./package.json
  {
      //...
      "scripts": {
@@ -41,82 +46,94 @@ In your package.json, add the `websmith` command as your build target to the `sc
  }
  ```
 
-### Build your project
+The default configuration uses the `tsconfig.json` file in your project root to compile the TypeScript files. Customize the compilation process with CLI arguments (e.g., `--addons`) or in the `websmith.config.json` file:
 
-The default configuration uses your `tsconfig.json` file to compile the TypeScript files and looks for compiler addons in the `./addons` directory.
+```json
+// ./websmith.config.json
+{
+    "addons": ["generate-client-proxies", "create-component-documentations"],
+}
+```
+
+Place your `websmith.config.json` file in the root of your project and add your addons to the `addons` directory next to it. Read more about addons in the [Customizing the compilation process](#customizing-the-compilation-process) section.
+
+### Use websmith with webpack
+
+You can use `websmith-loader` as drop-in replacement for the `ts-loader` to apply websmith addons to your TypeScript files.
+
+Install the `websmith-loader` package:
 
 ```bash
-pnpm build
+pnpm add --dev websmith-loader
+```
+
+In your webpack configuration, replace the `ts-loader` with the `websmith-loader`:
+
+```javascript
+module.exports = {
+    // ...
+    module: {
+        rules: [{ test: /\.tsx?$/, loader: 'websmith-loader' }],
+    },
+};
+```
+
+Add the `websmith-loader` to the `rules` section of your webpack configuration. The `websmith-loader` is configured with the `websmith.config.json` file in the root of your project or with the `config` option in the `websmith-loader` section:
+
+```javascript
+module.exports = {
+    // ...
+    module: {
+        rules: [{ test: /\.tsx?$/, loader: 'websmith-loader', options: { 
+            config: {
+                addonsDir: "./addons",
+                addons: ["export-yaml-configuration"],
+            },
+        } }],
+    },
+};
 ```
 
 ## Customizing the compilation process
 
-Add a compiler addon to generate new source files or restructure module dependencies before the actual compilation process. Use addons to process non-script files during the compilation, e.g., using Sass or PostCSS, or to generate documentation with YAML or Markdown and add them to the transpiled output.
+Compiler addons can be used for code generation, but also to process non-script files during the compilation, e.g. for style compilation with Sass or PostCSS, for documentation with YAML or Markdown.
 
-### Using compiler addons
+### Create a compiler addon
 
-An addon is a directory containing an ECMAScript module named `addon.ts` or `addon.js`. The file must have an exported function named `activate` that takes an `AddonContext` as its only parameter. Addons can register generators, processors or transformers to the compilation process:
+Websmith addons are ECMAScript modules with an `activate` function that takes an `AddonContext` as its only parameter. Install the `@quatico/websmith-api` package to use the `AddonContext` type:
+
+```bash
+pnpm add --dev @quatico/websmith-api
+```
+
+Create an directory e.g. `my-code-generator` in the `addons` folder in your project folder and add an ECMAScript module named `addon.ts` or `addon.js`:
 
 ```javascript
-// ./addons/foobar-transformer/addon.ts
+// ./addons/my-code-generator/addon.ts
 import { AddonContext } from '@quatico/websmith-api';
 import ts from "typescript";
 
 export const activate = (ctx: AddonContext) => {
     
-    // Use one of the register methods to add a generator, processor or transformer to the compilation process.
     ctx.registerGenerator((fileName: string, content: string): void => {
-        // for example, register a source generator
+        // for example, register a source generator to generate additional source inputs 
     });
     
     ctx.registerProcessor((fileName: string, content: string): string | never => {
-        // or, register a source processor
+        // or, register a source processor manipulate the source input before it's compiled
+    });
+
+    ctx.registerTransformer((options: ts.CustomTransformers): ts.CustomTransformers => {
+        // or, register a TypeScript transformer to manipulate the source input during the compilation
+    });
+
+    ctx.registerResultProcessor((fileNames: string[]): void => {
+        // or, register a result processor to manipulate the compiled output after the compilation
     });
 }
 ```
 
-The `activate` function is called when the compilation process is started.
-
-### Placing addons in your project
-
-Add for every addon a separate folder within the `./addons` directory. The folder name is used as addon name, if no explicit name is provided. The `addons` directory should be placed in the root of the project, i.e. next to your `tsconfig.json`. The `addons` directory is not part of your project's compilation process. You can specify a different location for your addons using the CLI argument `--addonsDir`.
-
-### Define which addons to use
-
-Use the CLI argument `--addons` to specify which addons to use. Provide a comma-separated list of addon names, i.e. the directory names of your addons.
-By default no addon is applied, even if addons are present in the `./addons` directory.
-
-### Provide a websmith configuration file
-
-Websmith looks for a `websmith.config.json` file in the root of your project. If it exists, it is used to configure the compilation process. The configuration file can be used to specify which addons to use. Provide a lists of addon names or define compilation profile to apply different addons for different profiles.
-
-Add an `addons` section to the `websmith.config.json` with the addon names to apply. All mentioned addons will be applied during the compilation:
-
-```json
-// ./websmith.config.json
-{ 
-    "addonsDir": "../my-addons",
-    "addons": ["foobar-transformer"],
-}
-```
-
-You can also define compilation profiles in the config file to use separate lists of addons for different compilation targets:
-
-```json
-// ./websmith.config.json
-{
-    "profiles": {
-        "client": {
-            "addons": ["generate-client-proxies", "create-component-documentation"],
-        },
-        "server": {
-            "addons": ["generate-service-functions"],
-        }
-    }
-}
-```
-
-Use `--profile` to run websmith with selected profile, e.g., `websmith --profile server`. If you use `--addons` in combination with `--profile`, the profile addons will be replaced by the addons provided with `--addons`. If you're having problems with addons not being correctly applied, please check the order of addon names. The order of addons in the config file is important! Addons are applied in the order they are defined.
+The file must have an exported function named `activate` that takes an `AddonContext` as its only parameter.
 
 ## Using compilation profiles
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,27 @@ export const activate = (ctx: AddonContext) => {
 
 The file must have an exported function named `activate` that takes an `AddonContext` as its only parameter.
 
+Read more about implementing addons in the [Write your own addon](docs/write-your-own-addon.md) section for detailed instructions and examples.
+
+### Find addon examples
+
+You can find a few examples for addons in the [@quatico/websmith-examples](https://github.com/quatico-solutions/websmith/tree/main/packages/example-addons) package.
+
+Install the `@quatico/websmith-examples` package to use the examples:
+
+```bash
+pnpm add --dev @quatico/websmith-examples
+```
+
+The `@quatico/websmith-examples` package contains the following examples:
+
+* `generate-client-proxies`: a simple addon to generate client proxies
+* `create-component-documentations`: a simple addon to create component documentations
+* `export-yaml-configuration`: a simple addon to export the configuration as YAML file
+* `foobar-added-generator`: a simple addon to generate additional source files
+* `foobar-export-processor`: a simple addon to process the compiled output after the compilation
+* `foobar-replace-transformer`: a simple addon to replace the source code during the compilation
+
 ## Using compilation profiles
 
 A compilation profile is a set of options that specify the environment for a compilation output. You can define a custom compilation profile by adding a `profiles` section to the `websmith.config.json` file. The `profiles` section contains a unique profile `name` and a set of options. The `name` is used to specify the profile when calling the websmith compiler. The options are used to configure the compilation process. The options contain the following sections:
@@ -174,6 +195,12 @@ An example for a custom compilation profile:
 }
 ```
 
-## Implementing compiler addons
+### Use a compilation profile
 
-See [Write your own addon](docs/write-your-own-addon.md) for detailed instructions and examples on how to write your own addon.
+To use a compilation profile, specify the profile name when calling the websmith compiler:
+
+```bash
+websmith --profile client
+```
+
+The compilation profile is applied to the compilation process and the addons are activated with the profile specific options.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,7 +72,7 @@ module.exports = [
                         ["@quatico/websmith-api", __dirname + "/packages/api/src"],
                         ["@quatico/websmith-compiler", __dirname + "/packages/compiler/src"],
                         ["@quatico/websmith-core", __dirname + "/packages/core/src"],
-                        ["@quatico/websmith-example-addons", __dirname + "/packages/example-addons/src"],
+                        ["@quatico/websmith-examples", __dirname + "/packages/example-addons/src"],
                         ["@quatico/websmith-node", __dirname + "/packages/node/src"],
                         ["@quatico/websmith-testing", __dirname + "/packages/testing/src"],
                         ["websmith-loader", __dirname + "/packages/webpack/src"],

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,16 +1,8 @@
 /*
- * @license
- *
- * Copyright (c) 2017-2024 Quatico Solutions AG
- * Förrlibuckstrasse 220, 8005 Zurich, Switzerland
- *
- * All Rights Reserved.
- *
- * This software is the confidential and proprietary information of
- * Quatico Solutions AG, ("Confidential Information"). You shall not
- * disclose such Confidential Information and shall use it only in
- * accordance with the terms of the license agreement you entered into
- * with Quatico.
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
  */
 import type { Config } from "jest";
 

--- a/packages/api/src/addons/index.ts
+++ b/packages/api/src/addons/index.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export type { AddonActivator } from "./AddonActivator";
 export type { AddonContext } from "./AddonContext";
 export type { Generator } from "./Generator";

--- a/packages/api/src/diagnostic/index.ts
+++ b/packages/api/src/diagnostic/index.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { ErrorMessage } from "./ErrorMessage";
 export { InfoMessage } from "./InfoMessage";
 export { aggregateMessages, messageToString } from "./messages";

--- a/packages/compiler-test/tests/compile-tsc.test.ts
+++ b/packages/compiler-test/tests/compile-tsc.test.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { compile } from "@quatico/websmith-node";
 import fs from "node:fs";
 import path from "node:path";

--- a/packages/compiler-test/tests/compile-websmith.test.ts
+++ b/packages/compiler-test/tests/compile-websmith.test.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { type CompilationConfig } from "@quatico/websmith-core";
 import { compile } from "@quatico/websmith-node";
 import fs from "node:fs";

--- a/packages/core/src/compiler/Compiler.test.ts
+++ b/packages/core/src/compiler/Compiler.test.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { ReporterMock } from "../../test";
 import { compileSystem } from "../testing";
 import { resolveCompilerOptions } from "./options";

--- a/packages/core/src/compiler/options/ResolvedCompilerOptions.spec.ts
+++ b/packages/core/src/compiler/options/ResolvedCompilerOptions.spec.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import ts from "typescript";
 import { ReporterMock } from "../../../test";
 import { compileSystem } from "../../testing";

--- a/packages/core/src/compiler/options/ResolvedCompilerOptions.ts
+++ b/packages/core/src/compiler/options/ResolvedCompilerOptions.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { type CompilationProfile, type Reporter } from "@quatico/websmith-api";
 import deepmerge, { type ArrayMergeOptions } from "deepmerge";
 import path from "node:path";

--- a/packages/core/src/compiler/options/ResolvedCompilerOptions.ts
+++ b/packages/core/src/compiler/options/ResolvedCompilerOptions.ts
@@ -234,19 +234,14 @@ const getProfile = (name?: string, config?: CompilationConfig): CompilationProfi
     return {};
 };
 
-const arrayMerge = (target: unknown[], source: unknown[], _options?: ArrayMergeOptions) => arrayUnique(source.concat(target));
-
-const arrayUnique = (array: unknown[]) => {
-    const result = array.concat();
-    for (let i = 0; i < result.length; ++i) {
-        for (let j = i + 1; j < result.length; ++j) {
-            if (result[i] === result[j]) {
-                result.splice(j--, 1);
-            }
-        }
-    }
-    return result;
-};
+/**
+ * Merges two arrays and removes duplicates.
+ *
+ * @param target - The target array.
+ * @param source - The source array.
+ * @returns A new array that is the result of merging the target and source arrays and removing duplicates.
+ */
+const arrayMerge = (target: unknown[], source: unknown[], _options?: ArrayMergeOptions) => [...new Set([...source, ...target])];
 
 const loadCompilationConfig = (
     options: Partial<CompilerOptions>,

--- a/packages/core/src/compiler/options/WebpackLoaderOptions.ts
+++ b/packages/core/src/compiler/options/WebpackLoaderOptions.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import type { BaseOptions } from "./BaseOptions";
 
 export type WebpackLoaderOptions = BaseOptions & {

--- a/packages/core/src/compiler/options/index.ts
+++ b/packages/core/src/compiler/options/index.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { type BaseOptions } from "./BaseOptions";
 export { type CompilerOptions } from "./CompilerOptions";
 export { ResolvedCompilerOptions } from "./ResolvedCompilerOptions";

--- a/packages/core/src/compiler/options/resolveCompilerOptions.ts
+++ b/packages/core/src/compiler/options/resolveCompilerOptions.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import type ts from "typescript";
 import { type CompilerOptions } from "./CompilerOptions";
 import { ResolvedCompilerOptions } from "./ResolvedCompilerOptions";

--- a/packages/core/src/environment/BrowserSystemOptions.ts
+++ b/packages/core/src/environment/BrowserSystemOptions.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import type ts from "typescript";
 
 export type BrowserSystemOptions = {

--- a/packages/core/src/environment/PathWatcherRegistry.ts
+++ b/packages/core/src/environment/PathWatcherRegistry.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import path from "node:path";
 import type ts from "typescript";
 import { resolvePath } from "./browser-system";

--- a/packages/core/src/environment/system.spec.ts
+++ b/packages/core/src/environment/system.spec.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { compileSystem } from "../testing";
 import { ignoreConfigFiles, recursiveFindByFilter } from "./system";
 

--- a/packages/core/src/testing/CompileSystem.ts
+++ b/packages/core/src/testing/CompileSystem.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import type ts from "typescript";
 import type { AddonRegistry } from "../compiler";
 

--- a/packages/core/src/testing/CompileSystemOptions.ts
+++ b/packages/core/src/testing/CompileSystemOptions.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import type { Reporter } from "@quatico/websmith-api";
 import type { AddonConfig } from "../compiler";
 import type { BrowserSystemOptions } from "../environment";

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { compileSystem } from "./compile-system";
 export { type CompileSystem } from "./CompileSystem";
 export { type CompileSystemOptions } from "./CompileSystemOptions";

--- a/packages/example-addons/package.json
+++ b/packages/example-addons/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@quatico/websmith-example-addons",
+    "name": "@quatico/websmith-examples",
     "version": "0.6.3",
     "description": "A library of example addons for the websmith compiler",
     "author": "Quatico Solutions AG",

--- a/packages/example-addons/src/client-processor/index.ts
+++ b/packages/example-addons/src/client-processor/index.ts
@@ -1,1 +1,7 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { activate as clientProcessorActivate } from "./addon";

--- a/packages/example-addons/src/client-transformer/index.ts
+++ b/packages/example-addons/src/client-transformer/index.ts
@@ -1,1 +1,7 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { activate as clientTransformerActivate } from "./addon";

--- a/packages/example-addons/src/export-yaml-generator/index.ts
+++ b/packages/example-addons/src/export-yaml-generator/index.ts
@@ -1,2 +1,8 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { activate as yamlGeneratorActivate } from "./addon";
 export * from "./export-transformer";

--- a/packages/example-addons/src/foo-added-generator/index.ts
+++ b/packages/example-addons/src/foo-added-generator/index.ts
@@ -1,1 +1,7 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { activate as generatorActivate } from "./addon";

--- a/packages/example-addons/src/foobar-export-processor/index.ts
+++ b/packages/example-addons/src/foobar-export-processor/index.ts
@@ -1,1 +1,7 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { activate as processorActivate } from "./addon";

--- a/packages/example-addons/src/foobar-replace-processor/index.ts
+++ b/packages/example-addons/src/foobar-replace-processor/index.ts
@@ -1,1 +1,7 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { activate as foobarReplaceProcessorActivate } from "./addon";

--- a/packages/example-addons/src/foobar-replace-transformer/index.ts
+++ b/packages/example-addons/src/foobar-replace-transformer/index.ts
@@ -1,2 +1,8 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { activate as foobarReplaceTransformerActivate } from "./addon";
 export { createReplaceIdentifierTransformer } from "./replace-identifier-transformer";

--- a/packages/example-addons/src/function-json-result-processor/index.ts
+++ b/packages/example-addons/src/function-json-result-processor/index.ts
@@ -1,1 +1,7 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { activate as resultProcessorActivate } from "./addon";

--- a/packages/example-addons/src/index.ts
+++ b/packages/example-addons/src/index.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export * from "./client-processor";
 export * from "./client-transformer";
 export * from "./export-yaml-generator";

--- a/packages/example-addons/src/server-processor/index.ts
+++ b/packages/example-addons/src/server-processor/index.ts
@@ -1,1 +1,7 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { activate as serverProcessorActivate } from "./addon";

--- a/packages/example-addons/src/server-transformer/index.ts
+++ b/packages/example-addons/src/server-transformer/index.ts
@@ -1,1 +1,7 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { activate as serverTransformerActivate } from "./addon";

--- a/packages/node/src/CompileError.ts
+++ b/packages/node/src/CompileError.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export class CompileError extends Error {
     private stdout?: string;
     private stderr?: string;

--- a/packages/node/src/Logger.spec.ts
+++ b/packages/node/src/Logger.spec.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Logger } from "./Logger";
 

--- a/packages/node/src/Logger.ts
+++ b/packages/node/src/Logger.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/packages/node/src/compiler-options.spec.ts
+++ b/packages/node/src/compiler-options.spec.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { parseNumberValue } from "./compiler-options";
 
 describe("parseNumberValue", () => {

--- a/packages/node/src/compiler-options.ts
+++ b/packages/node/src/compiler-options.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import ts from "typescript";
 
 export const tsDefaults: ts.CompilerOptions = {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export * from "./Logger";
 export * from "./tsc";
 export * from "./webpack";

--- a/packages/node/src/tsc/Compiler.spec.ts
+++ b/packages/node/src/tsc/Compiler.spec.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import path from "node:path";
 import ts from "typescript";
 import { tsDefaults } from "../compiler-options";

--- a/packages/node/src/tsc/Compiler.ts
+++ b/packages/node/src/tsc/Compiler.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { type ChildProcessWithoutNullStreams } from "node:child_process";
 import { spawn } from "cross-spawn";
 import { split } from "lodash";

--- a/packages/node/src/tsc/compile.spec.ts
+++ b/packages/node/src/tsc/compile.spec.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import path from "node:path";
 import { compile } from "./compile";
 import { Logger } from "../Logger";

--- a/packages/node/src/tsc/compile.ts
+++ b/packages/node/src/tsc/compile.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { type CompilerOptions as WebsmithOptions, DefaultReporter, Compiler as WebsmithCompiler } from "@quatico/websmith-core";
 import path from "node:path";
 import ts from "typescript";

--- a/packages/node/src/tsc/compiler-arguments.spec.ts
+++ b/packages/node/src/tsc/compiler-arguments.spec.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { parseCliArguments } from "./compiler-arguments";
 
 describe("parseCliArguments", () => {

--- a/packages/node/src/tsc/compiler-arguments.ts
+++ b/packages/node/src/tsc/compiler-arguments.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { isArray } from "lodash";
 import type ts from "typescript";
 import { parseNumberValue } from "../compiler-options";

--- a/packages/node/src/tsc/console-output.spec.ts
+++ b/packages/node/src/tsc/console-output.spec.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { parseReasonFromConsole } from "./console-output";
 
 describe("parseReasonFromConsole", () => {

--- a/packages/node/src/tsc/console-output.ts
+++ b/packages/node/src/tsc/console-output.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export const parseReasonFromConsole = (stdout: string, stderr: string) => {
     const console = stderr || stdout;
     const firstLine = console.split("\n")[0];

--- a/packages/node/src/tsc/find-tsc.ts
+++ b/packages/node/src/tsc/find-tsc.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 /* eslint-disable max-len */
 import os from "node:os";
 import path from "node:path";

--- a/packages/node/src/tsc/index.ts
+++ b/packages/node/src/tsc/index.ts
@@ -1,2 +1,8 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { compile } from "./compile";
 export { Compiler } from "./Compiler";

--- a/packages/node/src/webpack/WebpackBuild.spec.ts
+++ b/packages/node/src/webpack/WebpackBuild.spec.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { createFsFromVolume, Volume } from "memfs";
 import path from "node:path";
 import ts from "typescript";

--- a/packages/node/src/webpack/WebpackBuild.ts
+++ b/packages/node/src/webpack/WebpackBuild.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { type WebpackLoaderOptions } from "@quatico/websmith-core";

--- a/packages/node/src/webpack/index.ts
+++ b/packages/node/src/webpack/index.ts
@@ -1,2 +1,8 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { webpack } from "./webpack";
 export { WebpackBuild } from "./WebpackBuild";

--- a/packages/node/src/webpack/webpack-options.ts
+++ b/packages/node/src/webpack/webpack-options.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import path from "node:path";
 import { type Configuration } from "webpack";
 

--- a/packages/node/src/webpack/webpack-stats.ts
+++ b/packages/node/src/webpack/webpack-stats.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export const parseReasonFromStats = (stdout: string, stderr: string) => {
     const console = stderr || stdout;
     const firstLine = console.split("\n")[0];

--- a/packages/node/src/webpack/webpack.spec.ts
+++ b/packages/node/src/webpack/webpack.spec.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import fs from "node:fs";
 import path from "node:path";
 import { Logger } from "../Logger";

--- a/packages/node/src/webpack/webpack.ts
+++ b/packages/node/src/webpack/webpack.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { type WebpackLoaderOptions } from "@quatico/websmith-core";
 import { type LoaderOptions as TsLoaderOptions } from "ts-loader/dist/interfaces";
 import { type Configuration } from "webpack";

--- a/packages/webpack-test/src/client-function-with-import.ts
+++ b/packages/webpack-test/src/client-function-with-import.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { getFoobarServer } from "./functions/server-function";
 
 export function getFoobarClient(date: Date) {

--- a/packages/webpack-test/src/client-function.ts
+++ b/packages/webpack-test/src/client-function.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export function getFoobarClient(date: Date) {
     return `foobar ${date.toISOString()}`;
 }

--- a/packages/webpack-test/src/functions/getDate.ts
+++ b/packages/webpack-test/src/functions/getDate.ts
@@ -1,2 +1,8 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 // @service()
 export const getDate = (offsetHours: number) => new Date(new Date().getTime() + offsetHours * 60 * 60 * 1000);

--- a/packages/webpack-test/src/functions/server-function.ts
+++ b/packages/webpack-test/src/functions/server-function.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export function getFoobarServer(date: Date) {
     return `foobar ${date.toISOString()}`;
 }

--- a/packages/webpack-test/src/index.tsx
+++ b/packages/webpack-test/src/index.tsx
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { getDate } from "./functions/getDate";
 import { createMessage } from "./model";
 import React from "react";

--- a/packages/webpack-test/src/model/create-message.ts
+++ b/packages/webpack-test/src/model/create-message.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export const createMessage = () => ({
     message: "Test Test",
 });

--- a/packages/webpack-test/src/model/index.ts
+++ b/packages/webpack-test/src/model/index.ts
@@ -1,1 +1,7 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 export { createMessage } from "./create-message";

--- a/packages/webpack-test/tests/test-files.ts
+++ b/packages/webpack-test/tests/test-files.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import type { CompilationConfig } from "@quatico/websmith-core";
 import fs from "node:fs";
 import path from "node:path";

--- a/packages/webpack-test/tests/webpack-tsc.test.ts
+++ b/packages/webpack-test/tests/webpack-tsc.test.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { webpack } from "@quatico/websmith-node";
 import fs from "node:fs";
 import path from "node:path";

--- a/packages/webpack-test/tests/webpack-websmith.test.ts
+++ b/packages/webpack-test/tests/webpack-websmith.test.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { webpack } from "@quatico/websmith-node";
 import fs from "node:fs";

--- a/packages/webpack/src/WebsmithLoaderConfig.ts
+++ b/packages/webpack/src/WebsmithLoaderConfig.ts
@@ -1,3 +1,9 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
 import { type WebpackError } from "webpack";
 import { type WebpackLoaderOptions } from "@quatico/websmith-core";
 


### PR DESCRIPTION
This PR focuses on improving the main `README.md` file and adding license headers to various source files. Additionally, there are minor changes to configuration files. The most important changes are summarized below:

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R38): Expanded and clarified instructions for using `websmith`, including details on installation, configuration, and usage with webpack. Added examples of compiler addons and how to create custom addons. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R157) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L160-R206)

### License Updates:

* Added MIT license headers to multiple source files to ensure proper licensing information is included. [[1]](diffhunk://#diff-4848a47ad10455578ee777136483b9f0268cd702c0b44500a8ead5afb32a2e6dR1-R6) [[2]](diffhunk://#diff-a597d0e9bcc94b48294f88ae864ede1932d132e9284b870a2c5f3d39c1d96164R1-R6) [[3]](diffhunk://#diff-4af3f5cf6032e00c095955676bea28fcef82883915d074880d59b03b95e8a777R1-R6) [[4]](diffhunk://#diff-ebb18d772c669f141a6ead45294bb48aae4945c1e7bb503b99c5cd87494d2b78R1-R6) [[5]](diffhunk://#diff-1f1d959558851913231cf55a5ca67b4cf91932835e8f58c31c40e91fb6f4c61dR1-R6) [[6]](diffhunk://#diff-e533f05b204f70c62bcba50c3754bcc6898e5d2924828865b2bf9977e62e04cdR1-R6) [[7]](diffhunk://#diff-05f40245072d0403cb99d18778b38cddd30727844a3cc9e6690db09253e0c22cR1-R6) [[8]](diffhunk://#diff-e220ec87871a79412d782772e8e7ec6b57d29978063db04c30ed200cd12cae82R1-R6) [[9]](diffhunk://#diff-29d6253c32a460ace3c627c755857f08ce5ba81306670a47c60d663027de87e5R1-R6) [[10]](diffhunk://#diff-330636b360201e0ddadf15ac937a53375e15811942ee85ebaf1a32101a48f964R1-R6)

### Configuration Changes:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright year from 2024 to 2025.
* [`eslint.config.js`](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L75-R75): Renamed `@quatico/websmith-example-addons` to `@quatico/websmith-examples` for consistency.
* [`jest.config.ts`](diffhunk://#diff-860bd1f15d1e0bafcfc6f62560524f588e6d6bf56d4ab1b0f6f8146461558730L2-R5): Replaced the proprietary license header with the MIT license header.

These changes collectively improve the clarity of the documentation, ensure proper licensing, and maintain consistency across the codebase.