### PR TITLE
Markdown link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![CI](https://github.com/quatico-solutions/websmith/actions/workflows/protect-stable.yml/badge.svg)](https://github.com/quatico-solutions/websmith/actions/workflows/protect-stable.yml)  [![npm version](https://badge.fury.io/js/@quatico%2Fwebsmith-compiler.svg)](https://www.npmjs.com/search?q=%40quatico)
 
-This project is a compiler frontend for the [TypeScript compiler](https://github.com/microsoft/TypeScript). It's a drop-in replacement for the `tsc` command with additional customization options for the compilation output. You can apply compiler addons to modify the compilation input before, during and after compiled artifacts are created. Even non-script files can be processed during the compilation process. Use the `websmith` command with an addon:
+This project is a compiler frontend for the [TypeScript compiler](https://github.com/microsoft/TypeScript#readme). It's a drop-in replacement for the `tsc` command with additional customization options for the compilation output. You can apply compiler addons to modify the compilation input before, during and after compiled artifacts are created. Even non-script files can be processed during the compilation process. Use the `websmith` command with an addon:
 
 * To generate additional configuration or documentation based on the original source code,
 * To create additional new source files and add them to the compilation process, or
@@ -93,7 +93,7 @@ module.exports = {
 };
 ```
 
-<a name="customizing-the-compilation-output"></a>## Customizing the compilation output
+## <a name="customizing-the-compilation-output"></a>Customizing the compilation output
 
 Compiler addons can be used for code generation, but also to process non-script files during the compilation, e.g. for style compilation with Sass or PostCSS, for documentation with YAML or Markdown.
 
@@ -134,11 +134,11 @@ export const activate = (ctx: AddonContext) => {
 
 The file must have an exported function named `activate` that takes an `AddonContext` as its only parameter.
 
-Read more about implementing addons in the [Write your own addon](docs/write-your-own-addon.md) section for detailed instructions and examples.
+Read more about implementing addons in the [Write your own addon](packages/api/docs/write-your-own-addon.md) section for detailed instructions and examples.
 
 ### Find addon examples
 
-You can find a few examples for addons in the [@quatico/websmith-examples](https://github.com/quatico-solutions/websmith/tree/develop/packages/example-addons/README.md) package.
+You can find a few examples for addons in the [@quatico/websmith-examples](packages/example-addons#readme) package.
 
 Install the `@quatico/websmith-examples` package to use the examples:
 
@@ -207,4 +207,4 @@ To use a compilation profile, specify the profile name when calling the websmith
 }w
 ```
 
-The compilation profile is applied to the compilation process and the addons are activated with the profile specific options. For more information on how to activate addons, see the [compiler README](https://github.com/quatico-solutions/websmith/tree/develop/packages/compiler/README.md).
+The compilation profile is applied to the compilation process and the addons are activated with the profile specific options. For more information on how to activate addons, see the [compiler README](packages/compiler#readme).

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -16,11 +16,11 @@ Compiler addons can be used to modify the compilation artifacts before, during a
 
 Compiler addons can also access all transpiled files as whole and reason about the entire compilation target. The standard API for TypeScript transformers is fully integrated, thus existing `ts.CustomTransformers` can be simply called from within an addon.
 
-For a general introduction to websmith see the [websmith github repository](https://github.com/quatico-solutions/websmith).
+For a general introduction to websmith see the [websmith github repository](https://github.com/quatico-solutions/websmith#readme).
 
 ## Getting started
 
-The websmith API package is a peer dependency of the [websmith compiler](https://github.com/quatico-solutions/websmith) and provides the interfaces and functionality to implement compiler addons.
+The websmith API package is a peer dependency of the [websmith compiler](https://github.com/quatico-solutions/websmith/tree/develop/packages/compiler#readme) and provides the interfaces and functionality to implement compiler addons.
 
 ### Installation
 
@@ -57,7 +57,7 @@ export const activate: AddonActivator = (ctx: AddonContext<ComponentDocConfig>) 
 
 The `addon.ts` file must export an `activate` function implementing the `AddonActivator` interface. The `AddonActivator` type is a function that takes an `AddonContext` object as argument. You can use the `AddonContext` object to register a "generator", "processor", transformer" or "resultProcessor to the compilation process.
 
-For more information on how to implement addons, see the [write your own addon](../../docs/write-your-own-addon.md) documentation.
+For more information on how to implement addons, see the [write your own addon](docs/write-your-own-addon.md) documentation.
 
 ## Activate a compiler addon
 
@@ -72,4 +72,4 @@ You can activate your addon by using the `--addons` command line parameter when 
 }
 ```
 
-See the [compiler README]([../compiler/README.md](https://github.com/quatico-solutions/websmith/tree/develop/packages/compiler/README.md)) for more options on how to use addons.
+See the [compiler README](https://github.com/quatico-solutions/websmith/tree/develop/packages/compiler#readme) for more options on how to use addons.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -6,6 +6,6 @@
 -->
 # @quatico/websmith-core
 
-This package contains shared library functions for the websmith compiler. It's a peer dependency of the [@quatico/websmith-compiler](https://github.com/quatico-solutions/websmith/tree/develop/packages/compiler/README.md) package and should not be used directly. If you want to integrate websmith into your build process go to [@quatico/websmith-compiler](https://github.com/quatico-solutions/websmith/tree/develop/packages/compiler/README.md) for the `websmith` command line tool or to [websmith-loader](https://github.com/quatico-solutions/websmith/tree/develop/packages/webpack/README.md) for the webpack loader.
+This package contains shared library functions for the websmith compiler. It's a peer dependency of the [@quatico/websmith-compiler](https://github.com/quatico-solutions/websmith/tree/develop/packages/compiler#readme) package and should not be used directly. If you want to integrate websmith into your build process go to [@quatico/websmith-compiler](https://github.com/quatico-solutions/websmith/tree/develop/packages/compiler#readme) for the `websmith` command line tool or to [websmith-loader](https://github.com/quatico-solutions/websmith/tree/develop/packages/webpack#readme) for the webpack loader.
 
-See the [websmith github repository](https://github.com/quatico-solutions/websmith) for more information and examples.
+See the [websmith github repository](https://github.com/quatico-solutions/websmith#readme) for more information and examples.

--- a/packages/example-addons/README.md
+++ b/packages/example-addons/README.md
@@ -6,9 +6,9 @@
 -->
 # @quatico/websmith-examples
 
-A set of example addons to create your own `Generators`, `Processors` or `ResultProcessors` via the [@quatico/websmith-api](https://github.com/quatico-solutions/websmith/tree/develop/packages/api/README.md) to customize the compilation output.
+A set of example addons to create your own `Generators`, `Processors` or `ResultProcessors` via the [@quatico/websmith-api](https://github.com/quatico-solutions/websmith/tree/develop/packages/api#readme) to customize the compilation output.
 
-See the [websmith github repository](https://github.com/quatico-solutions/websmith) for a general introduction to the websmith compiler.
+See the [websmith github repository](https://github.com/quatico-solutions/websmith#readme) for a general introduction to the websmith compiler.
 
 ## Example Generator
 

--- a/packages/example-addons/README.md
+++ b/packages/example-addons/README.md
@@ -14,34 +14,34 @@ See the [websmith github repository](https://github.com/quatico-solutions/websmi
 
 The `foo-added-generator` addon is a generator that creates additional input files for the compilation. It creates an additional source file for every input file with substring "foo" in its file name. The additional file is named "*-added.ts" and contains the original file content. It is compiled with the same options as the original file.
 
-See example code in [foo-added-generator/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/examples/addons/foo-added-generator/addon.ts) for more details.
+See example code in [foo-added-generator/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/example-addons/src/foo-added-generator/addon.ts) for more details.
 
 ## Example Processor
 
 The `foobar-export-processor` addon is a processor that modifies all exports of ES modules. It finds all non exported "foobar" functions and adds an export modifier to the function declaration.
 
-See example code in [foobar-export-processor/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/examples/addons/foobar-export-processor/addon.ts) for more details.
+See example code in [foobar-export-processor/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/example-addons/src/foobar-export-processor/addon.ts) for more details.
 
 ## Example ResultProcessor
 
 The `function-json-result-processor` addon is a result processor that creates JSON data with all found function names. It consumes all processed source files to find function declarations and arrow functions to extract their names into a JSON file.
 
-See example code in [function-json-result-processor/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/examples/addons/function-json-result-processor/addon.ts) for more details.
+See example code in [function-json-result-processor/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/example-addons/src/function-json-result-processor/addon.ts) for more details.
 
 ## Example Transformer
 
 The `foobar-replace-transformer` addon is a transformer that modifies the source code inside a module. It finds all "foobar" identifiers in the source file and replaces them with the string "barfoo".
 
-See example code in [foobar-replace-transformer/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/examples/addons/foobar-replace-transformer/addon.ts) for more details.
+See example code in [foobar-replace-transformer/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/example-addons/src/foobar-replace-transformer/addon.ts) for more details.
 
 ## Example YAML Generator
 
 The `export-yaml-generator` is a generator that creates an additional YAML file describing all exported members per module. It creates an additional documentation file as compilation result for all files. It uses a TypeScript custom transformer to collect exported members per module.
 
-See example code in [export-yaml-generator/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/examples/addons/export-yaml-generator/addon.ts) for more details.
+See example code in [export-yaml-generator/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/example-addons/src/export-yaml-generator/addon.ts) for more details.
 
 ## Foobar Replace Processor vs. Transformer
 
 We demonstrate the differences between Processors and Transformer in  `foobar-replace-processor` and `foobar-replace-transformer`. The Former creates a processor that uses a TypeScript transformer to replace every found "foobar" identifier with "barfoo". The Latter creates a transformer that replaces every "foobar" identifier with "barfoo".
 
-See example code in [foobar-replace-processor/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/examples/addons/foobar-replace-processor/addon.ts) and [foobar-replace-transformer/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/examples/addons/foobar-replace-transformer/addon.ts) for more details.
+See example code in [foobar-replace-processor/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/example-addons/src/foobar-replace-processor/addon.ts) and [foobar-replace-transformer/addon.ts](https://github.com/quatico-solutions/websmith/tree/develop/packages/example-addons/src/foobar-replace-transformer/addon.ts) for more details.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -117,4 +117,4 @@ const logs = await webpack(["./src/index.ts"], {
 });
 ```
 
-See the [websmith github repository](https://github.com/quatico-solutions/websmith) for more information and examples.
+See the [websmith github repository](https://github.com/quatico-solutions/websmith#readme) for more information and examples.

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -6,9 +6,9 @@
 -->
 # websmith-loader
 
-A drop-in replacement for the [ts-loader](https://github.com/TypeStrong/ts-loader) to add the websmith compiler to your build and bundling process. Websmith provides an [API to create compiler addons](https://github.com/quatico-solutions/websmith/tree/develop/packages/api/README.md) to modify the compilation input before, during and after compiled artifacts are created, [compilation profiles](https://github.com/quatico-solutions/websmith/tree/develop/packages/compiler/README.md#compilation-profiles) to specify individual environments for different outputs, and integrates seamlessly with `webpack` build commands.
+A drop-in replacement for the [ts-loader](https://github.com/TypeStrong/ts-loader#readme) to add the websmith compiler to your build and bundling process. Websmith provides an [API to create compiler addons](https://github.com/quatico-solutions/websmith/tree/develop/packages/api#readme) to modify the compilation input before, during and after compiled artifacts are created, [compilation profiles](https://github.com/quatico-solutions/websmith/tree/develop/packages/compiler/README.md#compilation-profiles) to specify individual environments for different outputs, and integrates seamlessly with `webpack` build commands.
 
-Visit the [websmith github repository](https://github.com/quatico-solutions/websmith) for more information and examples.
+Visit the [websmith github repository](https://github.com/quatico-solutions/websmith#readme) for more information and examples.
 
 ## Getting started
 


### PR DESCRIPTION
This pull request includes several updates to README files across multiple packages to correct and standardize links to documentation and examples. The main changes involve updating the URLs to point to the correct sections or files within the GitHub repository.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11): Updated links to the TypeScript compiler and various sections within the repository. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R96) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L137-R141) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L210-R210)
* [`packages/api/README.md`](diffhunk://#diff-f3a9540595a860f97e334d7faaa974596dd800c0bb472c65427fddbde50d51b4L19-R23): Corrected links to the websmith GitHub repository and the write-your-own-addon documentation. [[1]](diffhunk://#diff-f3a9540595a860f97e334d7faaa974596dd800c0bb472c65427fddbde50d51b4L19-R23) [[2]](diffhunk://#diff-f3a9540595a860f97e334d7faaa974596dd800c0bb472c65427fddbde50d51b4L60-R60) [[3]](diffhunk://#diff-f3a9540595a860f97e334d7faaa974596dd800c0bb472c65427fddbde50d51b4L75-R75)
* [`packages/core/README.md`](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L9-R11): Updated links to the websmith compiler and loader documentation.
* [`packages/example-addons/README.md`](diffhunk://#diff-7847392907a75b7c216a5ccc284f9404355c8e98f14ff49df1d4e2f84ad174c3L9-R47): Fixed links to example addon files and the websmith GitHub repository.
* [`packages/node/README.md`](diffhunk://#diff-28333700bd7300f8ced1811261b0deb467d583021c08e658ad82f0134a08d25fL120-R120): Corrected the link to the websmith GitHub repository.
* [`packages/webpack/README.md`](diffhunk://#diff-01b58e2862c923c00556da243758bfa088ae4da49f415cc052d58a72f56f8953L9-R11): Updated links to ts-loader and websmith documentation.