### PR TITLE
B Fixes issue with un reported missing config file

### DIFF
--- a/packages/compiler/src/command.spec.ts
+++ b/packages/compiler/src/command.spec.ts
@@ -118,6 +118,20 @@ describe("addCompileCommand", () => {
         expect(target.getOptions().configFile).toEqual(expect.stringContaining("/expected/websmith.config.json"));
     });
 
+    it("should report missing config file w/o existing cli argument", () => {
+        const testSystem = compileSystem({}).fileSystem;
+        const target = new Compiler({ reporter: new NoReporter() }, {}, testSystem);
+        target.getReporter().reportDiagnostic = jest.fn();
+
+        addCompileCommand(new Command(), target).parse(["--configFile", "./does-not-exist/websmith.config.json"], { from: "user" });
+
+        expect(target.getOptions().config).toEqual({});
+        expect(target.getReporter().reportDiagnostic).toHaveBeenNthCalledWith(
+            1,
+            new WarnMessage(`No configuration file found at ${"/does-not-exist/websmith.config.json"}.`)
+        );
+    });
+
     it("should yield project option w/ --project cli argument", () => {
         const testSystem = compileSystem({ files: { "./expected/tsconfig.json": "{}" } }).fileSystem;
         const target = new Compiler({ reporter: new NoReporter() }, {}, testSystem);

--- a/packages/compiler/src/command.ts
+++ b/packages/compiler/src/command.ts
@@ -97,9 +97,8 @@ export const addCompileCommand = (parent = program, compiler?: Compiler): Comman
             // TODO: Add files from CLI argument
             const system = compiler?.getSystem() ?? createSystem();
             const reporter = compiler?.getReporter() ?? new DefaultReporter(system);
-            const options = createOptions(args, reporter, system);
-            options.configFile = args.configFile ?? "./websmith.config.json";
-            const compilationConfig = resolveCompilationConfig(options.configFile, reporter, system);
+            const compilationConfig = resolveCompilationConfig(args.configFile ?? "./websmith.config.json", reporter, system);
+            const options = createOptions({ ...args, configFile: args.configFile ?? "./websmith.config.json" }, reporter, system);
             const unknownArgs = (command?.args ?? []).filter(arg => !command.getOptionValueSource(arg));
             if (unknownArgs?.length > 0) {
                 options.additionalArguments = parseUnknownArguments(unknownArgs);


### PR DESCRIPTION
This pull request includes updates to the `addCompileCommand` function and its associated tests to improve error handling and configuration management.

Improvements to error handling and configuration management:

* [`packages/compiler/src/command.spec.ts`](diffhunk://#diff-70abd3ffca488c381d9e662768845321007a385940b511a8af86688a63c10258R121-R134): Added a test case to ensure that a missing configuration file is reported correctly when no existing CLI argument is provided.
* [`packages/compiler/src/command.ts`](diffhunk://#diff-7a57697a78229b6218b70725207703e7b01181cd235c8e6eb308f65f44016674L100-R101): Refactored the `addCompileCommand` function to handle the configuration file argument more effectively by resolving the compilation configuration before creating options and including the configuration file path in the options.