### PR TITLE
Improves test coverage to ensure profile addons from configFile are applied

### DIFF
--- a/packages/core/src/compiler/Compiler.spec.ts
+++ b/packages/core/src/compiler/Compiler.spec.ts
@@ -11,7 +11,7 @@ import ts from "typescript";
 import { ReporterMock } from "../../test";
 import { createSystem } from "../environment";
 import { Compiler, type CompileFragment } from "./Compiler";
-import type { AddonRegistry } from "./addons";
+import { AddonRegistry } from "./addons";
 import { type CompilationContext } from "./compilation";
 import { DefaultReporter } from "./DefaultReporter";
 import { type CompilerOptions, type ResolvedCompilerOptions, type WebpackLoaderOptions } from "./options";
@@ -291,6 +291,216 @@ describe("constructor", () => {
             expect(testObj.getOptions().configFile).toMatch(/different\/websmith\.config\.json$/);
         });
     });
+
+    it("yields addons with addons property in configFile", () => {
+        const target = createSystem(
+            {
+                "./websmith.config.json": JSON.stringify({ profiles: { "target-profile": { addons: ["addon1", "addon2"] } } }, null, 2),
+            },
+            { virtual: true }
+        );
+
+        const testObj = new CompilerTestClass(
+            {
+                reporter: new ReporterMock(target),
+                configFile: "./websmith.config.json",
+            },
+            undefined,
+            target
+        );
+
+        const actual = testObj.getOptions().getAddons("target-profile");
+
+        expect(actual).toEqual(["addon1", "addon2"]);
+    });
+
+    it("yields addons with profile and addons property in configFile", () => {
+        const target = createSystem(
+            {
+                "./websmith.config.json": JSON.stringify({ profiles: { "target-profile": { addons: ["addon1", "addon2"] } } }, null, 2),
+            },
+            { virtual: true }
+        );
+
+        const testObj = new CompilerTestClass(
+            {
+                reporter: new ReporterMock(target),
+                configFile: "./websmith.config.json",
+                profile: "target-profile",
+            },
+            undefined,
+            target
+        );
+
+        const actual = testObj.getOptions().getAddons();
+
+        expect(actual).toEqual(["addon1", "addon2"]);
+    });
+
+    it("yields addons with profile and addons property in config property", () => {
+        const target = createSystem({}, { virtual: true });
+        createAddon(target, "addons/expected1/addon");
+        createAddon(target, "addons/expected2/addon");
+        createAddon(target, "addons/expected3/addon");
+
+        const testObj = new CompilerTestClass(
+            {
+                reporter: new ReporterMock(target),
+                config: {
+                    profiles: {
+                        "target-profile": {
+                            addons: ["expected1", "expected2"],
+                        },
+                        other: {
+                            addons: ["expected3"],
+                        },
+                    },
+                },
+                profile: "target-profile",
+            },
+            undefined,
+            target,
+            new AddonRegistry({
+                addonsDir: "addons",
+                system: target,
+                reporter: new ReporterMock(target),
+                profiles: {
+                    "target-profile": {
+                        addons: ["expected1", "expected2"],
+                    },
+                    other: {
+                        addons: ["expected3"],
+                    },
+                },
+            })
+        );
+
+        expect(testObj.getOptions().getAddons()).toEqual(["expected1", "expected2"]);
+        expect(testObj.getOptions().getAddons("target-profile")).toEqual(["expected1", "expected2"]);
+        expect(testObj.getOptions().getAddons("other")).toEqual(["expected3"]);
+        expect(testObj.getAddonRegistry()!.getAvailableAddons("target-profile").getNames()).toEqual(["expected1", "expected2"]);
+        expect(testObj.getAddonRegistry()!.getAvailableAddons("other").getNames()).toEqual(["expected3"]);
+    });
+
+    it("yields addons without profile and addons property in config property", () => {
+        const target = createSystem({}, { virtual: true });
+        createAddon(target, "addons/expected1/addon");
+        createAddon(target, "addons/expected2/addon");
+        createAddon(target, "addons/expected3/addon");
+
+        const testObj = new CompilerTestClass(
+            {
+                reporter: new ReporterMock(target),
+                config: {
+                    profiles: {
+                        "target-profile": {
+                            addons: ["expected1", "expected2"],
+                        },
+                        other: {
+                            addons: ["expected3"],
+                        },
+                    },
+                },
+            },
+            undefined,
+            target,
+            new AddonRegistry({
+                addonsDir: "addons",
+                system: target,
+                reporter: new ReporterMock(target),
+                profiles: {
+                    "target-profile": {
+                        addons: ["expected1", "expected2"],
+                    },
+                    other: {
+                        addons: ["expected3"],
+                    },
+                },
+            })
+        ).createProfileContextsIfNecessary();
+
+        expect(testObj.getOptions().getAddons()).toEqual([]);
+        expect(testObj.getAddonRegistry()!.getAvailableAddons("target-profile").getNames()).toEqual(["expected1", "expected2"]);
+        expect(testObj.getAddonRegistry()!.getAvailableAddons("other").getNames()).toEqual(["expected3"]);
+    });
+
+    it("yields tsConfig from profile and tsConfig property in configFile", () => {
+        const target = createSystem(
+            {
+                "./websmith.config.json": JSON.stringify(
+                    {
+                        profiles: {
+                            "target-profile": {
+                                tsConfig: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ES2022 },
+                            },
+                        },
+                    },
+                    null,
+                    2
+                ),
+            },
+            { virtual: true }
+        );
+
+        const testObj = new CompilerTestClass(
+            {
+                reporter: new ReporterMock(target),
+                configFile: "./websmith.config.json",
+                profile: "target-profile",
+            },
+            undefined,
+            target
+        ).createProfileContextsIfNecessary();
+
+        expect(testObj.getOptions().getOptions("target-profile").tsConfig).toMatchObject({
+            target: ts.ScriptTarget.ES2022,
+            module: ts.ModuleKind.ES2022,
+        });
+
+        expect(testObj.getContext("target-profile")!.getCliArgs().options).toMatchObject({
+            target: ts.ScriptTarget.ES2022,
+            module: ts.ModuleKind.ES2022,
+        });
+    });
+
+    it("yields tsConfig from profile and tsConfig property in config", () => {
+        const target = createSystem(
+            {
+                "./websmith.config.json": JSON.stringify(
+                    {
+                        profiles: {
+                            "target-profile": {
+                                tsConfig: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ES2022 },
+                            },
+                        },
+                    },
+                    null,
+                    2
+                ),
+            },
+            { virtual: true }
+        );
+
+        const testObj = new CompilerTestClass(
+            {
+                reporter: new ReporterMock(target),
+                configFile: "./websmith.config.json",
+                profile: "target-profile",
+            },
+            undefined,
+            target
+        ).createProfileContextsIfNecessary();
+
+        expect(testObj.getOptions().getOptions("target-profile").tsConfig).toMatchObject({
+            target: ts.ScriptTarget.ES2022,
+            module: ts.ModuleKind.ES2022,
+        });
+
+        expect(testObj.getContext("target-profile")!.getCliArgs().options).toMatchObject({
+            target: ts.ScriptTarget.ES2022,
+            module: ts.ModuleKind.ES2022,
+        });
+    });
 });
 
 describe("getSystem", () => {
@@ -374,6 +584,110 @@ describe("setOptions", () => {
             }
             "
         `);
+    });
+
+    it("yields addons with addons property in configFile", () => {
+        const target = createSystem(
+            {
+                "./websmith.config.json": JSON.stringify({ profiles: { "target-profile": { addons: ["addon1", "addon2"] } } }, null, 2),
+            },
+            { virtual: true }
+        );
+
+        const testObj = new CompilerTestClass(
+            {
+                reporter: new ReporterMock(target),
+            },
+            undefined,
+            target
+        );
+
+        testObj.setOptions({
+            configFile: "./websmith.config.json",
+        });
+
+        const actual = testObj.getOptions().getAddons("target-profile");
+
+        expect(actual).toEqual(["addon1", "addon2"]);
+    });
+
+    it("yields addons with profile and addons property in configFile", () => {
+        const target = createSystem(
+            {
+                "./websmith.config.json": JSON.stringify({ profiles: { "target-profile": { addons: ["addon1", "addon2"] } } }, null, 2),
+            },
+            { virtual: true }
+        );
+
+        const testObj = new CompilerTestClass(
+            {
+                reporter: new ReporterMock(target),
+            },
+            undefined,
+            target
+        );
+
+        testObj.setOptions({
+            configFile: "./websmith.config.json",
+            profile: "target-profile",
+        });
+
+        const actual = testObj.getOptions().getAddons();
+
+        expect(actual).toEqual(["addon1", "addon2"]);
+    });
+
+    it("yields addons with profile and addons property in config property", () => {
+        const target = createSystem({}, { virtual: true });
+
+        const testObj = new CompilerTestClass(
+            {
+                reporter: new ReporterMock(target),
+            },
+            undefined,
+            target
+        );
+
+        testObj.setOptions({
+            config: {
+                profiles: {
+                    "target-profile": {
+                        addons: ["addon1", "addon2"],
+                    },
+                },
+            },
+        });
+
+        const actual = testObj.getOptions().getAddons("target-profile");
+
+        expect(actual).toEqual(["addon1", "addon2"]);
+    });
+
+    it("yields addons with profile and addons property and addons in profile property", () => {
+        const target = createSystem({}, { virtual: true });
+
+        const testObj = new CompilerTestClass(
+            {
+                reporter: new ReporterMock(target),
+            },
+            undefined,
+            target
+        );
+
+        testObj.setOptions({
+            config: {
+                addons: [],
+                profiles: {
+                    "target-profile": {
+                        addons: ["addon1", "addon2"],
+                    },
+                },
+            },
+        });
+
+        const actual = testObj.getOptions().getAddons("target-profile");
+
+        expect(actual).toEqual(["addon1", "addon2"]);
     });
 });
 
@@ -1387,3 +1701,14 @@ const getText = (name: string, output: CompileFragment): string => {
 
 const getFilesByExtension = (output: CompileFragment, ...extensions: string[]): ts.OutputFile[] =>
     output.files.filter(it => extensions.includes(complexFileExtension(it.name)));
+
+const createAddon = (testSystem: ts.System, path: string, code = "export const activate = () => {};", mock: object = { activate: jest.fn() }) => {
+    testSystem.writeFile(`./${path}.js`, code);
+    jest.mock(
+        `/${path}`,
+        () => {
+            return mock;
+        },
+        { virtual: true }
+    );
+};

--- a/packages/core/src/compiler/Compiler.ts
+++ b/packages/core/src/compiler/Compiler.ts
@@ -342,9 +342,7 @@ export class Compiler {
 
             cache.updateSource(filePath, content);
 
-            const result = this.processOutput(cache, this.transpile({ fileName, ctx, content }), writeFile, fileName, ctx);
-
-            return result;
+            return this.processOutput(cache, this.transpile({ fileName, ctx, content }), writeFile, fileName, ctx);
         }
 
         throw new Error(`No profile with name "${profile}" configured.`);
@@ -498,11 +496,9 @@ export class Compiler {
             } else {
                 const isSourceFile = (name: string) => name.match(/\.([cm]?ts|tsx)$/i);
                 if (!isSourceFile(fileName)) {
-                    const result = this.transpileJson(compilationFragment);
-                    return result;
+                    return this.transpileJson(compilationFragment);
                 }
-                const result = this.transpileSourceCode(compilationFragment);
-                return result;
+                return this.transpileSourceCode(compilationFragment);
             }
         }
 

--- a/packages/core/src/compiler/config/parsed-command-line.ts
+++ b/packages/core/src/compiler/config/parsed-command-line.ts
@@ -4,6 +4,7 @@
  *   Licensed under the MIT License. See LICENSE in the project root for license information.
  * ---------------------------------------------------------------------------------------------
  */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { aggregateMessages, COMPILER_ARGUMENT_KEYS, type CompilerArgumentKey, type CompilerArguments } from "@quatico/websmith-api";
 import ts from "typescript";
 
@@ -14,7 +15,7 @@ import ts from "typescript";
  * @param system
  */
 export const parsedCommandLine = (tsConfigFile: string, args: CompilerArguments, system: ts.System): ts.ParsedCommandLine | never => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     const { config, tsConfig, ...restArgs } = args as any; // TODO: Flatten compiler arguments seems a brittle solution
 
     const flattenedArgs = { ...restArgs, ...config, ...tsConfig };

--- a/packages/core/src/compiler/options/ResolvedCompilerOptions.spec.ts
+++ b/packages/core/src/compiler/options/ResolvedCompilerOptions.spec.ts
@@ -4,6 +4,8 @@
  *   Licensed under the MIT License. See LICENSE in the project root for license information.
  * ---------------------------------------------------------------------------------------------
  */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import ts from "typescript";
 import { ReporterMock } from "../../../test";
 import { createSystem } from "../../environment";


### PR DESCRIPTION
This pull request introduces several improvements and new tests for the handling of addons and TypeScript configuration profiles in the `Compiler` class, as well as minor code cleanups and linting adjustments. The main focus is on expanding test coverage for addon/profile resolution logic and simplifying some code paths.

**Expanded test coverage for addons and profiles:**

* Added comprehensive tests in `Compiler.spec.ts` to verify that the `Compiler` correctly resolves `addons` and `tsConfig` options from various sources, including `configFile`, `config` property, and different profile scenarios. This includes tests for both the constructor and the `setOptions` method. [[1]](diffhunk://#diff-e9bb40efaa43242723091791235ccc8ffc6d3cd2bf4ed6863c8a39621f0ad605R294-R503) [[2]](diffhunk://#diff-e9bb40efaa43242723091791235ccc8ffc6d3cd2bf4ed6863c8a39621f0ad605R588-R691)
* Introduced a utility function `createAddon` to facilitate mocking addons in tests.

**Code simplification and cleanup:**

* Refactored some return statements in `Compiler.ts` to be more concise by removing unnecessary intermediate variables. [[1]](diffhunk://#diff-6942fa4fb182fbf2de1407e3251628b7c45aaa16dd0d25a6a3ac1984950566aeL345-R345) [[2]](diffhunk://#diff-6942fa4fb182fbf2de1407e3251628b7c45aaa16dd0d25a6a3ac1984950566aeL501-R501)

**Linting and type safety adjustments:**

* Disabled specific TypeScript ESLint rules in `parsed-command-line.ts` and `ResolvedCompilerOptions.spec.ts` to allow for more flexible argument handling and assignment in test and config parsing code. [[1]](diffhunk://#diff-48bfdd41dcaa2198b80ecd046728b751ae21e3c8a1e629deaa59ad7d466c2386R7) [[2]](diffhunk://#diff-48bfdd41dcaa2198b80ecd046728b751ae21e3c8a1e629deaa59ad7d466c2386L17-R18) [[3]](diffhunk://#diff-ebb18d772c669f141a6ead45294bb48aae4945c1e7bb503b99c5cd87494d2b78R7-R8)

These changes improve the reliability of addon/profile resolution, make the core logic easier to maintain, and ensure future changes are well-covered by tests.