### PR TITLE
84 file names from cli are not passed to the compiler

### DIFF
--- a/packages/compiler/jest.config.ts
+++ b/packages/compiler/jest.config.ts
@@ -14,6 +14,7 @@ const config: Config = {
         "@quatico/websmith-core": "<rootDir>/../core/src",
         "@quatico/websmith-testing": "<rootDir>/../testing/src",
     },
+    watchPathIgnorePatterns: ["test-output*"],
 };
 
 export default config;

--- a/packages/compiler/src/bin.spec.ts
+++ b/packages/compiler/src/bin.spec.ts
@@ -497,11 +497,255 @@ describe("bin.ts", () => {
         expect(getOutput("named-functions.json")).toMatchInlineSnapshot(`"{"foobar-function":["getFoobar","foobar"]}"`);
     }, 60000);
 
+    it("should pass only included files to compiler context with tsconfig include pattern", () => {
+        const target = new Compiler({ reporter: new NoReporter() }, {}, createSystem());
+        createTsConfigFile({
+            outDir: testDirs.OUTPUT_DIR,
+            noEmit: false,
+            target: ts.ScriptTarget.ESNext,
+            moduleResolution: ts.ModuleResolutionKind.Node10,
+        });
+        createSourceFile("export const included1 = 'test';", "included1.ts");
+        createSourceFile("export const included2 = 'test';", "included2.ts");
+        createSourceFile("export const excluded = 'test';", "excluded.js");
+        createSourceFile("export const subIncluded = 'test';", "subdir/subIncluded.ts");
+        createSourceFile("export const outsideSrc = 'test';", "../outsideSrc.ts");
+        createSourceFile("File is not a TypeScript file", "excluded.txt");
+
+        executeCompiler(`--project ${path.join(testDirs.PROJECT_DIR, "tsconfig.json")}`, target);
+
+        // @ts-expect-error - getContext is protected
+        const actual = target.getContext()!.getCliArgs().fileNames || [];
+
+        // Should include TypeScript files from src directory and subdirectories
+        expect(actual).toEqual(
+            expect.arrayContaining([
+                expect.stringMatching(/src[/\\]included1\.ts$/),
+                expect.stringMatching(/src[/\\]included2\.ts$/),
+                expect.stringMatching(/src[/\\]subdir[/\\]subIncluded\.ts$/),
+            ])
+        );
+
+        // Should not include .js files or files outside src
+        expect(actual).not.toEqual(expect.arrayContaining([expect.stringMatching(/excluded\.js$/), expect.stringMatching(/outsideSrc\.ts$/)]));
+    }, 60000);
+
+    it("should pass only included files with custom include pattern", () => {
+        const target = new Compiler({ reporter: new NoReporter() }, {}, createSystem({}));
+        createTsConfigFile(
+            {
+                outDir: testDirs.OUTPUT_DIR,
+                noEmit: false,
+                target: ts.ScriptTarget.ESNext,
+                moduleResolution: ts.ModuleResolutionKind.Node10,
+            },
+            ["src/custom/**/*.ts"],
+            ["node_modules", "dist"]
+        );
+
+        createSourceFile("export const included1 = 'test';", "custom/included1.ts");
+        createSourceFile("export const included2 = 'test';", "custom/included2.ts");
+        createSourceFile("export const excluded = 'test';", "excluded.ts");
+        createSourceFile("export const excluded2 = 'test';", "other/excluded.ts");
+        createSourceFile("File is not a TypeScript file", "excluded.txt");
+        createSourceFile("File is not a TypeScript file", ".gitignore");
+
+        executeCompiler(`--project ${path.join(testDirs.PROJECT_DIR, "tsconfig.json")}`, target);
+
+        // @ts-expect-error - getContext is protected
+        const actual = target.getContext()?.getCliArgs().fileNames || [];
+
+        // Should only include files from src/custom directory
+        expect(actual).toEqual(
+            expect.arrayContaining([expect.stringMatching(/src\/custom\/included1\.ts$/), expect.stringMatching(/src\/custom\/included2\.ts$/)])
+        );
+
+        // Should not include files from other directories
+        expect(actual).not.toEqual(
+            expect.arrayContaining([
+                expect.stringMatching(/[^/\\]excluded\.ts$/), // excluded.ts in src/
+                expect.stringMatching(/other[/\\]excluded\.ts$/), // excluded.ts in src/other/
+            ])
+        );
+
+        // Verify exact count to ensure no unexpected files are included
+        expect(actual).toHaveLength(2);
+    }, 60000);
+
+    it("should pass explicitly specified files when provided as CLI arguments", () => {
+        const target = new Compiler({ reporter: new NoReporter() }, {}, createSystem({}));
+        createTsConfigFile({
+            outDir: testDirs.OUTPUT_DIR,
+            noEmit: false,
+            target: ts.ScriptTarget.ESNext,
+            moduleResolution: ts.ModuleResolutionKind.Node10,
+        });
+        createSourceFile("export const file1 = 'test';", "file1.ts");
+        createSourceFile("export const file2 = 'test';", "file2.ts");
+        createSourceFile("export const file3 = 'test';", "file3.ts");
+
+        // Execute compiler with specific files using relative paths
+        const file1Rel = "src/file1.ts";
+        const file3Rel = "src/file3.ts";
+        executeCompiler(`${file1Rel} ${file3Rel} --project tsconfig.json`, target);
+
+        // @ts-expect-error - getContext is protected
+        const actual = target.getContext()?.getCliArgs().fileNames || [];
+
+        // Should only include the explicitly specified files
+        expect(actual).toHaveLength(2);
+        expect(actual).toEqual(expect.arrayContaining([expect.stringMatching(/file1\.ts$/), expect.stringMatching(/file3\.ts$/)]));
+
+        // Should not include file2.ts since it wasn't specified
+        expect(actual).not.toEqual(expect.arrayContaining([expect.stringMatching(/file2\.ts$/)]));
+    }, 60000);
+
+    it("should pass files according to exclude pattern", () => {
+        const target = new Compiler({ reporter: new NoReporter() }, {}, createSystem({}));
+        createTsConfigFile(
+            {
+                outDir: testDirs.OUTPUT_DIR,
+                noEmit: false,
+                target: ts.ScriptTarget.ESNext,
+                moduleResolution: ts.ModuleResolutionKind.Node10,
+            },
+            ["src/**/*.ts"],
+            ["node_modules", "dist", "src/excluded/**/*"]
+        );
+
+        createSourceFile("export const included = 'test';", "included.ts");
+        createSourceFile("export const excluded = 'test';", "excluded/excluded.ts");
+        createSourceFile("export const included2 = 'test';", "normal/included.ts");
+
+        executeCompiler(`--project ${path.join(testDirs.PROJECT_DIR, "tsconfig.json")}`, target);
+
+        // @ts-expect-error - getContext is protected
+        const actual = target.getContext()?.getCliArgs().fileNames || [];
+
+        // Should include files not in excluded directory
+        expect(actual).toEqual(
+            expect.arrayContaining([
+                expect.stringMatching(/src[/\\]included\.ts$/), // included.ts in src/
+                expect.stringMatching(/src[/\\]normal[/\\]included\.ts$/), // included.ts in src/normal/
+            ])
+        );
+
+        // Should not include files from excluded directory
+        expect(actual).not.toEqual(expect.arrayContaining([expect.stringMatching(/excluded[/\\]excluded\.ts$/)]));
+    }, 60000);
+
+    it("should pass files from cli args according to exclude pattern", () => {
+        const target = new Compiler({ reporter: new NoReporter() }, {}, createSystem({}));
+        createTsConfigFile(
+            {
+                outDir: testDirs.OUTPUT_DIR,
+                noEmit: false,
+                target: ts.ScriptTarget.ESNext,
+                moduleResolution: ts.ModuleResolutionKind.Node10,
+            },
+            ["src/**/*.ts"],
+            ["node_modules", "dist", "src/excluded/**/*"]
+        );
+
+        const filePath = createSourceFile("export const included = 'test';", "included.ts");
+        createSourceFile("export const excluded = 'test';", "excluded/excluded.ts");
+        createSourceFile("export const included2 = 'test';", "other.ts");
+
+        executeCompiler(`${filePath} --project ${path.join(testDirs.PROJECT_DIR, "tsconfig.json")}`, target);
+
+        // @ts-expect-error - getContext is protected
+        const actual = target.getContext()?.getCliArgs().fileNames || [];
+
+        // Should include files not in excluded directory
+        expect(actual).toEqual(
+            expect.arrayContaining([
+                expect.stringMatching(/src[/\\]included\.ts$/), // included.ts in src/
+            ])
+        );
+
+        // Should not include files from excluded directory
+        expect(actual).not.toEqual(expect.arrayContaining([expect.stringMatching(/excluded[/\\]excluded\.ts$/)]));
+    }, 60000);
+
+    it("should include all tsconfig properties in cliArgs.options", () => {
+        const target = new Compiler({ reporter: new NoReporter() }, {}, createSystem({}));
+        createTsConfigFile({
+            outDir: testDirs.OUTPUT_DIR,
+            noEmit: false,
+            target: ts.ScriptTarget.ES2020,
+            moduleResolution: ts.ModuleResolutionKind.Node10,
+            strict: true,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            allowSyntheticDefaultImports: true,
+            declaration: true,
+            sourceMap: true,
+        });
+        createSourceFile("export const test = 'hello';", "test.ts");
+
+        executeCompiler(`--project ${path.join(testDirs.PROJECT_DIR, "tsconfig.json")}`, target);
+
+        // @ts-expect-error - getContext is protected
+        const cliArgs = target.getContext()?.getCliArgs();
+        const options = cliArgs?.options;
+
+        // Verify that tsconfig options are properly included in cliArgs.options
+        expect(options?.target).toBe(ts.ScriptTarget.ES2020);
+        expect(options?.moduleResolution).toBe(ts.ModuleResolutionKind.Node10);
+        expect(options?.strict).toBe(true);
+        expect(options?.esModuleInterop).toBe(true);
+        expect(options?.skipLibCheck).toBe(true);
+        expect(options?.forceConsistentCasingInFileNames).toBe(true);
+        expect(options?.allowSyntheticDefaultImports).toBe(true);
+        expect(options?.declaration).toBe(true);
+        expect(options?.sourceMap).toBe(true);
+        expect(options?.outDir).toBe(testDirs.OUTPUT_DIR);
+    }, 60000);
+
+    it("should include all tsconfig properties in cliArgs.options even with explicit files", () => {
+        const target = new Compiler({ reporter: new NoReporter() }, {}, createSystem({}));
+        createTsConfigFile({
+            outDir: testDirs.OUTPUT_DIR,
+            noEmit: false,
+            target: ts.ScriptTarget.ES2020,
+            moduleResolution: ts.ModuleResolutionKind.Node10,
+            strict: true,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+        });
+        createSourceFile("export const test1 = 'hello';", "test1.ts");
+        createSourceFile("export const test2 = 'hello';", "test2.ts");
+
+        // Execute with explicit files
+        executeCompiler(`src/test1.ts --project ${path.join(testDirs.PROJECT_DIR, "tsconfig.json")}`, target);
+
+        // @ts-expect-error - getContext is protected
+        const cliArgs = target.getContext()?.getCliArgs();
+        const options = cliArgs?.options;
+
+        // Verify that tsconfig options are still included even with explicit files
+        expect(options?.target).toBe(ts.ScriptTarget.ES2020);
+        expect(options?.moduleResolution).toBe(ts.ModuleResolutionKind.Node10);
+        expect(options?.strict).toBe(true);
+        expect(options?.esModuleInterop).toBe(true);
+        expect(options?.skipLibCheck).toBe(true);
+        expect(options?.forceConsistentCasingInFileNames).toBe(true);
+        expect(options?.outDir).toBe(testDirs.OUTPUT_DIR);
+
+        // Verify that only the explicit file is included
+        expect(cliArgs?.fileNames).toHaveLength(1);
+        expect(cliArgs?.fileNames?.[0]).toMatch(/test1\.ts$/);
+    }, 60000);
+
     const executeCompiler = (args = "", compiler?: Compiler) => {
         process.chdir(testDirs.PROJECT_DIR);
 
         try {
-            addCompileCommand(new Command(), compiler).parse(args.split(" "), { from: "user" });
+            // Handle argument parsing more carefully to support file paths with spaces
+            const argArray = typeof args === "string" ? args.split(/\s+/) : args;
+            addCompileCommand(new Command(), compiler).parse(argArray, { from: "user" });
         } catch (err: any) {
             // Check if this was a successful exit (help shown, etc.)
             if (err?.message?.includes("process.exit() was called during test")) {
@@ -514,7 +758,7 @@ describe("bin.ts", () => {
         }
     };
 
-    const createTsConfig = (config: ts.CompilerOptions) => {
+    const createTsConfig = (config: ts.CompilerOptions, include: string[] = ["src/**/*"], exclude: string[] = ["node_modules", "dist"]) => {
         // Convert enum values to strings for proper JSON serialization
         const normalizedConfig = {
             ...config,
@@ -528,14 +772,14 @@ describe("bin.ts", () => {
 
         const tsConfig = {
             compilerOptions: normalizedConfig,
-            include: ["src/**/*"],
-            exclude: ["node_modules", "dist"],
+            include,
+            exclude,
         };
         return JSON.stringify(tsConfig, null, 2);
     };
 
-    const createTsConfigFile = (config: ts.CompilerOptions) => {
-        fs.writeFileSync(path.join(testDirs.PROJECT_DIR, "tsconfig.json"), createTsConfig(config), { encoding: "utf-8" });
+    const createTsConfigFile = (config: ts.CompilerOptions, include?: string[], exclude?: string[]) => {
+        fs.writeFileSync(path.join(testDirs.PROJECT_DIR, "tsconfig.json"), createTsConfig(config, include, exclude), { encoding: "utf-8" });
     };
 
     const createWebsmithConfig = (config: CompilationConfig) => {
@@ -546,8 +790,17 @@ describe("bin.ts", () => {
         fs.copyFileSync(path.resolve(TEST_FILES_DIR, fileName), path.resolve(testDirs.SOURCE_DIR, fileName));
     };
 
-    const createSourceFile = (fileContent: string, fileName: string) => {
-        fs.writeFileSync(path.join(testDirs.SOURCE_DIR, fileName), fileContent, { encoding: "utf-8" });
+    const createSourceFile = (fileContent: string, fileName: string): string => {
+        const filePath = path.join(testDirs.SOURCE_DIR, fileName);
+        const dirPath = path.dirname(filePath);
+
+        // Create subdirectories if they don't exist
+        if (!fs.existsSync(dirPath)) {
+            fs.mkdirSync(dirPath, { recursive: true });
+        }
+
+        fs.writeFileSync(filePath, fileContent, { encoding: "utf-8" });
+        return filePath;
     };
 
     const getOutput = (filePath: string): string | undefined =>

--- a/packages/compiler/src/command.ts
+++ b/packages/compiler/src/command.ts
@@ -85,18 +85,31 @@ export const addCompileCommand = (parent = program, compiler?: Compiler): Comman
             }
         })
         .action((args: CompilerArguments, command: Command) => {
-            // TODO: Add files from CLI argument
             const system = compiler?.getSystem() ?? ts.sys;
             const reporter = compiler?.getReporter() ?? new DefaultReporter(system);
             const tsConfigFile = args.project ?? "./tsconfig.json";
 
+            // Extract file arguments from command line
+            const unknownArgs = (command?.args ?? []).filter(arg => !command.getOptionValueSource(arg));
+            const fileArguments = unknownArgs.filter(
+                arg => !arg.startsWith("-") && (arg.endsWith(".ts") || arg.endsWith(".tsx") || arg.endsWith(".js") || arg.endsWith(".jsx"))
+            );
+            const otherUnknownArgs = unknownArgs.filter(arg => !fileArguments.includes(arg));
+
             const options: CompilerOptions = {
                 tsConfigFile,
-                ...createOptions({ ...args, project: tsConfigFile }, reporter, system),
+                ...createOptions(
+                    {
+                        ...args,
+                        project: tsConfigFile,
+                        // Pass file arguments through args so they get picked up by parsedCommandLine
+                        ...(fileArguments.length > 0 && { fileNames: fileArguments }),
+                    },
+                    reporter,
+                    system
+                ),
             };
-
-            const unknownArgs = (command?.args ?? []).filter(arg => !command.getOptionValueSource(arg));
-            if (unknownArgs?.length > 0) {
+            if (otherUnknownArgs?.length > 0) {
                 // Check for common typos and warn about them
                 const commonTypos = [
                     { wrong: "--tsConfigFile", correct: "--project" },
@@ -105,13 +118,13 @@ export const addCompileCommand = (parent = program, compiler?: Compiler): Comman
                 ];
 
                 for (const typo of commonTypos) {
-                    if (unknownArgs.includes(typo.wrong)) {
+                    if (otherUnknownArgs.includes(typo.wrong)) {
                         reporter.reportDiagnostic(
                             new WarnMessage(`Unknown option "${typo.wrong}". Did you mean "${typo.correct}"? Use --help to see available options.`)
                         );
                     }
                 }
-                options.additionalArguments = parseUnknownArguments(unknownArgs);
+                options.additionalArguments = parseUnknownArguments(otherUnknownArgs);
             }
             if (options.profile && hasInvalidProfile(options.profile, options.config)) {
                 reporter.reportDiagnostic(

--- a/packages/core/src/compiler/Compiler.spec.ts
+++ b/packages/core/src/compiler/Compiler.spec.ts
@@ -839,7 +839,11 @@ describe("compile", () => {
         const fileSystem = createSystem({ "src/target.ts": `export const computeDate = async (): Promise<Date> => new Date();` }, { virtual: true });
 
         new CompilerTestClass(
-            { reporter: new ReporterMock(fileSystem), tsConfig: { target: ts.ScriptTarget.ESNext } },
+            {
+                reporter: new ReporterMock(fileSystem),
+                tsConfig: { target: ts.ScriptTarget.ESNext },
+                cliArgs: { fileNames: ["src/target.ts"], options: {}, errors: [] },
+            },
             undefined,
             fileSystem
         ).compile();

--- a/packages/core/src/compiler/config/parsed-command-line.ts
+++ b/packages/core/src/compiler/config/parsed-command-line.ts
@@ -15,8 +15,7 @@ import ts from "typescript";
  * @param system
  */
 export const parsedCommandLine = (tsConfigFile: string, args: CompilerArguments, system: ts.System): ts.ParsedCommandLine | never => {
-     
-    const { config, tsConfig, ...restArgs } = args as any; // TODO: Flatten compiler arguments seems a brittle solution
+    const { config, tsConfig, fileNames, ...restArgs } = args as any; // TODO: Flatten compiler arguments seems a brittle solution
 
     const flattenedArgs = { ...restArgs, ...config, ...tsConfig };
 
@@ -65,9 +64,45 @@ export const parsedCommandLine = (tsConfigFile: string, args: CompilerArguments,
         ...(profiles ? { profiles } : {}),
     };
 
-    const tscArgs = ts.parseCommandLine(createArgs(rest));
+    // Create command line args and add file arguments if provided
+    const commandLineArgs = createArgs(rest);
+    if (fileNames && Array.isArray(fileNames)) {
+        commandLineArgs.push(...fileNames);
+    }
+    const tscArgs = ts.parseCommandLine(commandLineArgs);
 
     if (tsConfigFile && system.fileExists(tsConfigFile)) {
+        // If explicit files were provided as CLI arguments, still use tsconfig options but not file discovery
+        if (tscArgs.fileNames.length > 0) {
+            // Parse tsconfig to get the compiler options but ignore file discovery
+            const tsConfigResult = ts.getParsedCommandLineOfConfigFile(
+                system.resolvePath(tsConfigFile),
+                {
+                    ...extraArgs,
+                    ...tscArgs.options, // CLI options can override tsconfig.json
+                },
+                parseHost,
+                undefined /* no extended config cache */,
+                undefined /* no extra watch options */,
+                undefined /* no extra file extensions */
+            );
+
+            if (!tsConfigResult) {
+                throw new Error(errorMessage);
+            }
+
+            return {
+                ...tsConfigResult,
+                options: {
+                    ...(configFile ? { configFile: system.resolvePath(configFile) } : {}),
+                    ...(watch ? { watch: true } : {}),
+                    ...(instanceName ? { instanceName } : {}),
+                    ...tsConfigResult.options, // Include all tsconfig options
+                },
+                fileNames: tscArgs.fileNames, // Use explicit files instead of tsconfig file discovery
+            };
+        }
+
         const result = ts.getParsedCommandLineOfConfigFile(
             system.resolvePath(tsConfigFile),
             {

--- a/packages/core/src/compiler/options/ResolvedCompilerOptions.spec.ts
+++ b/packages/core/src/compiler/options/ResolvedCompilerOptions.spec.ts
@@ -34,7 +34,7 @@ describe("constructor", () => {
                 buildDir: "/",
                 cliArgs: expect.objectContaining({
                     errors: [],
-                    fileNames: ["/build/test.ts"],
+                    fileNames: [],
                     options: expect.objectContaining({
                         allowJs: false,
                         checkJs: false,
@@ -689,7 +689,7 @@ describe("cliArgs", () => {
 
         expect(testObj.cliArgs).toEqual({
             errors: [],
-            fileNames: ["/test.ts"],
+            fileNames: [],
             options: {
                 allowJs: false,
                 checkJs: false,
@@ -992,7 +992,7 @@ describe("getOptions", () => {
             buildDir: "/",
             cliArgs: {
                 errors: [],
-                fileNames: ["/test.ts"],
+                fileNames: [],
                 options: {
                     allowJs: false,
                     checkJs: false,

--- a/packages/core/src/compiler/options/ResolvedCompilerOptions.ts
+++ b/packages/core/src/compiler/options/ResolvedCompilerOptions.ts
@@ -9,7 +9,7 @@ import deepmerge, { type ArrayMergeOptions } from "deepmerge";
 import path from "node:path";
 import type ts from "typescript";
 import type { CompilerOptionsValue } from "typescript";
-import { recursiveFindByFilter } from "../../environment";
+
 import { parsedCommandLine, resolveCompilationConfig, resolvePath, resolvePaths, resolveProfile, type CompilationConfig } from "../config";
 import { DefaultReporter } from "../DefaultReporter";
 import { tsDefaults } from "../defaults";
@@ -184,26 +184,39 @@ export class ResolvedCompilerOptions implements CompilerOptions {
             options: { ...(cliArgs?.options ?? {}), ...(outDir && { outDir }), ...(rootDir && { rootDir }) },
         };
 
-        this.cliArgs = deepmerge<ts.ParsedCommandLine>(
-            deepmerge<ts.ParsedCommandLine>(
-                this.tsConfigFile && this.system.fileExists(this.tsConfigFile) ? parsedCommandLine(this.tsConfigFile, {}, this.system) : {},
-                {
-                    options: {
-                        ...(outDir && { outDir }),
-                        ...(this.tsConfig && { ...this.tsConfig }),
-                    },
-                },
-                { arrayMerge }
-            ),
+        // Get the parsed command line from tsconfig.json which includes proper file discovery
+        const parsedTsConfig =
+            this.tsConfigFile && this.system.fileExists(this.tsConfigFile) ? parsedCommandLine(this.tsConfigFile, {}, this.system) : {};
+
+        // Determine if we should use CLI files or tsconfig file discovery
+        const useCliFiles = cliArgs?.fileNames?.length > 0;
+        const finalFileNames = useCliFiles
+            ? cliArgs.fileNames.map(fileName => this.system.resolvePath(fileName))
+            : (parsedTsConfig as ts.ParsedCommandLine)?.fileNames || [];
+
+        const baseCliArgs = deepmerge<ts.ParsedCommandLine>(
+            parsedTsConfig,
             {
-                ...premergedCliArgs,
-                fileNames: cliArgs?.fileNames?.length
-                    ? cliArgs.fileNames.map(fileName => this.system.resolvePath(fileName))
-                    : recursiveFindByFilter(this.system.resolvePath(this.buildDir), undefined, this.system),
-                errors: [],
+                options: {
+                    ...(outDir && { outDir }),
+                    ...(this.tsConfig && { ...this.tsConfig }),
+                },
             },
             { arrayMerge }
         );
+
+        // When CLI files are provided, replace fileNames instead of merging
+        this.cliArgs = {
+            ...baseCliArgs,
+            ...premergedCliArgs,
+            // Ensure all tsconfig options are included in cliArgs.options
+            options: {
+                ...baseCliArgs.options, // This includes all tsconfig options from parsedTsConfig
+                ...premergedCliArgs.options, // This includes CLI-specific options like outDir, rootDir
+            },
+            fileNames: finalFileNames,
+            errors: [],
+        };
         this.tsConfig = deepmerge<ts.CompilerOptions>(this.tsConfig, this.cliArgs?.options ?? {}, { arrayMerge });
 
         if (this.tsConfig?.sourceMap === false) {


### PR DESCRIPTION
This pull request introduces improvements to how CLI file arguments and `tsconfig` include/exclude patterns are handled in the compiler. It ensures that files passed on the command line are properly respected, and that `tsconfig` options are consistently included in the compiler context. The changes also add comprehensive tests for these scenarios and improve argument parsing robustness.

**CLI Argument & tsconfig Handling Improvements:**

* Improved the logic in `parsedCommandLine` (`parsed-command-line.ts`) to ensure that when explicit file arguments are provided via the CLI, those files are used instead of files discovered through `tsconfig` patterns, while still applying all relevant `tsconfig` options. (`[[1]](diffhunk://#diff-48bfdd41dcaa2198b80ecd046728b751ae21e3c8a1e629deaa59ad7d466c2386L18-R18)`, `[[2]](diffhunk://#diff-48bfdd41dcaa2198b80ecd046728b751ae21e3c8a1e629deaa59ad7d466c2386L68-R105)`)
* Updated the `addCompileCommand` function (`command.ts`) to extract file arguments from the CLI, pass them through to the compiler context, and handle unknown arguments more robustly. (`[[1]](diffhunk://#diff-7a57697a78229b6218b70725207703e7b01181cd235c8e6eb308f65f44016674L88-R112)`, `[[2]](diffhunk://#diff-7a57697a78229b6218b70725207703e7b01181cd235c8e6eb308f65f44016674L108-R127)`)

**Testing Enhancements:**

* Added extensive new tests in `bin.spec.ts` to verify that file inclusion/exclusion from CLI and `tsconfig` works as expected, including support for custom include/exclude patterns and explicit file arguments. Also improved test utilities to support these scenarios. (`[[1]](diffhunk://#diff-5f4df07579feb5446ef182e8e0c4c6b60a4157d77c1a6bf14922d5521a738ba5R500-R748)`, `[[2]](diffhunk://#diff-5f4df07579feb5446ef182e8e0c4c6b60a4157d77c1a6bf14922d5521a738ba5L517-R761)`, `[[3]](diffhunk://#diff-5f4df07579feb5446ef182e8e0c4c6b60a4157d77c1a6bf14922d5521a738ba5L531-R782)`, `[[4]](diffhunk://#diff-5f4df07579feb5446ef182e8e0c4c6b60a4157d77c1a6bf14922d5521a738ba5L549-R803)`)

**Other Improvements:**

* Updated references and expectations in related tests (`ResolvedCompilerOptions.spec.ts`, `Compiler.spec.ts`) to align with the new handling of file arguments and options. (`[[1]](diffhunk://#diff-e9bb40efaa43242723091791235ccc8ffc6d3cd2bf4ed6863c8a39621f0ad605L842-R846)`, `[[2]](diffhunk://#diff-ebb18d772c669f141a6ead45294bb48aae4945c1e7bb503b99c5cd87494d2b78L37-R37)`, `[[3]](diffhunk://#diff-ebb18d772c669f141a6ead45294bb48aae4945c1e7bb503b99c5cd87494d2b78L692-R692)`, `[[4]](diffhunk://#diff-ebb18d772c669f141a6ead45294bb48aae4945c1e7bb503b99c5cd87494d2b78L995-R995)`)
* Added `watchPathIgnorePatterns` to the Jest config to ignore test output files during watch mode. (`[packages/compiler/jest.config.tsR17](diffhunk://#diff-d9f23c8a32584f10a8b5c3f001dad851fe3446c79710b5efe20ace8f44bb4cccR17)`)