### PR TITLE
89 dont issue warnings for shared folders within addonsdir

### DIFF
--- a/packages/compiler/src/command-cli-args.spec.ts
+++ b/packages/compiler/src/command-cli-args.spec.ts
@@ -1,0 +1,401 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
+import { Compiler, createSystem, NoReporter } from "@quatico/websmith-core";
+import { Command } from "commander";
+import { addCompileCommand } from "./command";
+
+beforeEach(() => {
+    jest.spyOn(process.stderr, "write").mockImplementation(() => true);
+    jest.spyOn(console, "time").mockImplementation(() => {});
+});
+
+describe("addCompileCommand", () => {
+    describe("Command Structure", () => {
+        it("should create compile command with proper basic setup", () => {
+            const command = addCompileCommand(new Command());
+
+            expect(command).toBeDefined();
+            expect(command.name()).toBe("websmith");
+            expect(command.description()).toBe("Compiles typescript source code and applies addons to transform source before or after emit.");
+            // Verify that the command allows unknown options and excess arguments
+            // @ts-expect-error -- cannot access private properties
+            expect(command._allowUnknownOption).toBe(true);
+            // @ts-expect-error -- cannot access private properties
+            expect(command._allowExcessArguments).toBe(true);
+        });
+
+        it("should allow unknown options and excess arguments", () => {
+            const command = addCompileCommand(new Command());
+
+            // @ts-expect-error -- cannot access private properties
+            expect(command._allowUnknownOption).toBe(true);
+            // @ts-expect-error -- cannot access private properties
+            expect(command._allowExcessArguments).toBe(true);
+        });
+    });
+
+    describe("CLI Options", () => {
+        let command: Command;
+
+        beforeEach(() => {
+            command = addCompileCommand(new Command());
+        });
+
+        it("should have all expected CLI options defined", () => {
+            // Test the command help output to verify options are defined
+            const helpOutput = command.helpInformation();
+
+            // Configuration options
+            expect(helpOutput).toContain("--configFile");
+            expect(helpOutput).toContain("--project");
+            expect(helpOutput).toContain("--addons");
+            expect(helpOutput).toContain("--addonsDir");
+            expect(helpOutput).toContain("--profile");
+
+            // Mode options
+            expect(helpOutput).toContain("--debug");
+            expect(helpOutput).toContain("--transpileOnly");
+            expect(helpOutput).toContain("--watch");
+
+            // TypeScript compiler options
+            expect(helpOutput).toContain("--target");
+            expect(helpOutput).toContain("--module");
+            expect(helpOutput).toContain("--lib");
+            expect(helpOutput).toContain("--allowJs");
+            expect(helpOutput).toContain("--checkJs");
+            expect(helpOutput).toContain("--jsx");
+            expect(helpOutput).toContain("--declaration");
+            expect(helpOutput).toContain("--declarationMap");
+            expect(helpOutput).toContain("--emitDeclarationOnly");
+            expect(helpOutput).toContain("--sourceMap");
+            expect(helpOutput).toContain("--noEmit");
+            expect(helpOutput).toContain("--outFile");
+            expect(helpOutput).toContain("--outDir");
+            expect(helpOutput).toContain("--removeComments");
+            expect(helpOutput).toContain("--strict");
+            expect(helpOutput).toContain("--types");
+            expect(helpOutput).toContain("--esModuleInterop");
+
+            // Build options
+            expect(helpOutput).toContain("--init");
+            expect(helpOutput).toContain("--showConfig");
+            expect(helpOutput).toContain("--build");
+            expect(helpOutput).toContain("--pretty");
+        });
+
+        it("should have proper short option aliases", () => {
+            const helpOutput = command.helpInformation();
+
+            expect(helpOutput).toContain("-c, --configFile");
+            expect(helpOutput).toContain("-p, --project");
+            expect(helpOutput).toContain("-o, --transpileOnly");
+            expect(helpOutput).toContain("-w, --watch");
+            expect(helpOutput).toContain("-t, --target");
+            expect(helpOutput).toContain("-m, --module");
+            expect(helpOutput).toContain("-d, --declaration");
+            expect(helpOutput).toContain("-b, --build");
+            expect(helpOutput).toContain("-a, --addons");
+            expect(helpOutput).toContain("-f, --addonsDir");
+            expect(helpOutput).toContain("-l, --profile");
+        });
+    });
+
+    describe("Option Validation", () => {
+        it("should create command that accepts websmith-specific options", () => {
+            const command = addCompileCommand(new Command());
+            const helpOutput = command.helpInformation();
+
+            expect(helpOutput).toContain("--addons");
+            expect(helpOutput).toContain("--addonsDir");
+            expect(helpOutput).toContain("--profile");
+            expect(helpOutput).toContain("Comma-separated list of addons");
+            expect(helpOutput).toContain("Directory path to the");
+        });
+    });
+
+    describe("Option Descriptions", () => {
+        it("should have proper descriptions for compilation options", () => {
+            const command = addCompileCommand(new Command());
+            const helpOutput = command.helpInformation();
+
+            expect(helpOutput).toContain("Enable watch mode");
+            expect(helpOutput).toContain("Enable the output of debug information");
+            expect(helpOutput).toContain("Enable the transpile only mode");
+            expect(helpOutput).toContain('File path to the "websmith.config.json"');
+        });
+
+        it("should have proper descriptions for TypeScript options", () => {
+            const command = addCompileCommand(new Command());
+            const helpOutput = command.helpInformation();
+
+            expect(helpOutput).toContain("Set the JavaScript language version");
+            expect(helpOutput).toContain("Specify what module code is generated");
+            expect(helpOutput).toContain("Generate .d.ts files");
+            expect(helpOutput).toContain("Create source map files");
+            expect(helpOutput).toContain("Enable all strict type-checking options");
+        });
+
+        it("should have proper descriptions for build options", () => {
+            const command = addCompileCommand(new Command());
+            const helpOutput = command.helpInformation();
+
+            expect(helpOutput).toContain("Initializes a TypeScript project");
+            expect(helpOutput).toContain("Print the final configuration");
+            expect(helpOutput).toContain("Build one or more projects");
+            expect(helpOutput).toContain("Enable color and formatting");
+        });
+    });
+
+    describe("Option Values", () => {
+        it("should document TypeScript target values", () => {
+            const command = addCompileCommand(new Command());
+            const helpOutput = command.helpInformation();
+
+            expect(helpOutput).toContain("es5");
+            expect(helpOutput).toContain("es2015");
+            expect(helpOutput).toContain("es2020");
+            expect(helpOutput).toContain("esnext");
+        });
+
+        it("should document module system values", () => {
+            const command = addCompileCommand(new Command());
+            const helpOutput = command.helpInformation();
+
+            expect(helpOutput).toContain("commonjs");
+            expect(helpOutput).toContain("amd");
+            expect(helpOutput).toContain("umd");
+            expect(helpOutput).toContain("system");
+        });
+
+        it("should document JSX values", () => {
+            const command = addCompileCommand(new Command());
+            const helpOutput = command.helpInformation();
+
+            expect(helpOutput).toContain("preserve");
+            expect(helpOutput).toContain("react");
+            expect(helpOutput).toContain("react-jsx");
+        });
+    });
+
+    describe("CLI argument handling", () => {
+        let compiler: Compiler;
+
+        beforeEach(() => {
+            compiler = new Compiler({ reporter: new NoReporter() }, undefined, createSystem({}, { virtual: true }));
+        });
+
+        describe("Boolean Options", () => {
+            it("should handle --debug flag", () => {
+                executeCompiler("--debug", compiler);
+
+                expect(compiler.getOptions().tsConfig!.debug).toBe(true);
+            });
+
+            it("should handle --strict flag", () => {
+                executeCompiler("--strict", compiler);
+
+                expect(compiler.getOptions().tsConfig!.strict).toBe(true);
+            });
+
+            it("should handle --declaration flag", () => {
+                executeCompiler("--declaration", compiler);
+
+                expect(compiler.getOptions().tsConfig!.declaration).toBe(true);
+            });
+
+            it("should handle --sourceMap flag", () => {
+                executeCompiler("--sourceMap", compiler);
+
+                expect(compiler.getOptions().tsConfig!.sourceMap).toBe(true);
+            });
+
+            it("should handle --transpileOnly flag", () => {
+                executeCompiler("--transpileOnly", compiler);
+
+                expect(compiler.getOptions().config?.transpileOnly).toBe(true);
+            });
+
+            it("should handle multiple boolean flags together", () => {
+                executeCompiler("--debug --strict --declaration", compiler);
+
+                expect(compiler.getOptions().tsConfig!.debug).toBe(true);
+                expect(compiler.getOptions().tsConfig!.strict).toBe(true);
+                expect(compiler.getOptions().tsConfig!.declaration).toBe(true);
+            });
+        });
+
+        describe("String Options", () => {
+            it("should handle --target option", () => {
+                executeCompiler("--target es2020", compiler);
+
+                expect(compiler.getOptions().tsConfig!.target).toBe(7); // es2020 enum value
+            });
+
+            it("should handle --module option", () => {
+                executeCompiler("--module commonjs", compiler);
+
+                expect(compiler.getOptions().tsConfig!.module).toBe(1); // commonjs enum value
+            });
+
+            it("should handle --outDir option", () => {
+                executeCompiler("--outDir ./dist", compiler);
+
+                expect(compiler.getOptions().tsConfig!.outDir).toBe("/dist"); // Resolved path
+            });
+
+            it("should handle --project option", () => {
+                executeCompiler("--project ./custom-tsconfig.json", compiler);
+
+                expect(compiler.getOptions().tsConfig!.project).toBe("./custom-tsconfig.json");
+            });
+        });
+
+        describe("Configuration Options", () => {
+            it("should handle --configFile option", () => {
+                executeCompiler("--configFile ./custom-websmith.config.json", compiler);
+
+                expect(compiler.getOptions().configFile).toBe("/custom-websmith.config.json"); // Resolved path
+            });
+
+            it("should handle -c (configFile) short option", () => {
+                executeCompiler("-c ./websmith.config.json", compiler);
+
+                expect(compiler.getOptions().configFile).toBe("/websmith.config.json"); // Resolved path
+            });
+
+            it("should handle --addonsDir option", () => {
+                executeCompiler("--addonsDir ./custom-addons", compiler);
+
+                // The addonsDir should be configured in the addon registry
+                const registry = compiler.getAddonRegistry();
+                expect(registry).toBeDefined();
+            });
+
+            it("should handle -f (addonsDir) short option", () => {
+                executeCompiler("-f ./my-addons", compiler);
+
+                // The addonsDir should be configured in the addon registry
+                const registry = compiler.getAddonRegistry();
+                expect(registry).toBeDefined();
+            });
+
+            it("should handle --profile option", () => {
+                executeCompiler("--profile development", compiler);
+
+                expect(compiler.getOptions().profile).toBe("development");
+            });
+
+            it("should handle -l (profile) short option", () => {
+                executeCompiler("-l production", compiler);
+
+                expect(compiler.getOptions().profile).toBe("production");
+            });
+        });
+
+        describe("Short Options", () => {
+            it("should handle -t (target) short option", () => {
+                executeCompiler("-t es2021", compiler);
+
+                expect(compiler.getOptions().tsConfig!.target).toBe(8); // es2021 enum value
+            });
+
+            it("should handle -d (declaration) short option", () => {
+                executeCompiler("-d", compiler);
+
+                expect(compiler.getOptions().tsConfig!.declaration).toBe(true);
+            });
+
+            it("should handle -o (transpileOnly) short option", () => {
+                executeCompiler("-o", compiler);
+
+                expect(compiler.getOptions().config?.transpileOnly).toBe(true);
+            });
+        });
+
+        describe("Addon Options", () => {
+            it("should handle --addons option", () => {
+                executeCompiler("--addons addon1,addon2", compiler);
+
+                // The addons should be configured in the addon registry
+                const registry = compiler.getAddonRegistry();
+                expect(registry).toBeDefined();
+            });
+
+            it("should handle -a (addons) short option", () => {
+                executeCompiler("-a transform1,transform2", compiler);
+
+                // The addons should be configured in the addon registry
+                const registry = compiler.getAddonRegistry();
+                expect(registry).toBeDefined();
+            });
+        });
+
+        describe("Option Combinations", () => {
+            it("should handle mixed short and long options", () => {
+                executeCompiler("-t es2020 --strict -d", compiler);
+
+                expect(compiler.getOptions().tsConfig!.target).toBe(7); // es2020 enum value
+                expect(compiler.getOptions().tsConfig!.strict).toBe(true);
+                expect(compiler.getOptions().tsConfig!.declaration).toBe(true);
+            });
+
+            it("should handle profile with TypeScript options", () => {
+                executeCompiler("--profile custom --target es2021", compiler);
+
+                expect(compiler.getOptions().profile).toBe("custom");
+                expect(compiler.getOptions().tsConfig!.target).toBe(8); // es2021 enum value
+            });
+
+            it("should handle addons with build options", () => {
+                executeCompiler("--addons test-addon --declaration", compiler);
+
+                expect(compiler.getOptions().tsConfig!.declaration).toBe(true);
+                const registry = compiler.getAddonRegistry();
+                expect(registry).toBeDefined();
+            });
+
+            it("should handle configuration options together", () => {
+                executeCompiler("--configFile ./config.json --addonsDir ./addons --profile test", compiler);
+
+                expect(compiler.getOptions().configFile).toBe("/config.json"); // Resolved path
+                expect(compiler.getOptions().profile).toBe("test");
+                const registry = compiler.getAddonRegistry();
+                expect(registry).toBeDefined();
+            });
+
+            it("should handle configuration short options with TypeScript options", () => {
+                executeCompiler("-c ./config.json -f ./addons -l dev --target es2020", compiler);
+
+                expect(compiler.getOptions().configFile).toBe("/config.json"); // Resolved path
+                expect(compiler.getOptions().profile).toBe("dev");
+                expect(compiler.getOptions().tsConfig!.target).toBe(7); // es2020 enum value
+                const registry = compiler.getAddonRegistry();
+                expect(registry).toBeDefined();
+            });
+        });
+    });
+});
+
+const executeCompiler = (args = "", compiler?: Compiler) => {
+    try {
+        const command = addCompileCommand(new Command(), compiler);
+        // Parse arguments like the existing tests do
+        command.parse(
+            args
+                .split(" ")
+                .map(it => it.trim())
+                .filter(it => it !== ""),
+            { from: "user" }
+        );
+    } catch (err: any) {
+        // Only throw for actual errors, not for expected exits or compilation completion
+        if (err.message && !err.message.includes("process.exit") && !err.message.includes("compilation")) {
+            throw err;
+        }
+        // Swallow expected exits from successful compilation
+    }
+};

--- a/packages/compiler/src/command.spec.ts
+++ b/packages/compiler/src/command.spec.ts
@@ -12,7 +12,7 @@ import path from "node:path";
 import ts from "typescript";
 import { addCompileCommand, addonConfig, hasInvalidProfile } from "./command";
 
-beforeAll(() => {
+beforeEach(() => {
     jest.spyOn(console, "time").mockImplementation(() => {});
 });
 

--- a/packages/core/src/compiler/addons/AddonRegistry.spec.ts
+++ b/packages/core/src/compiler/addons/AddonRegistry.spec.ts
@@ -700,9 +700,10 @@ describe("Addon Compilation", () => {
         const target = new ReporterMock(system);
         system.createDirectory(ADDONS_DIR);
         system.createDirectory(`${ADDONS_DIR}/missing-import-addon`);
+        system.writeFile(`${ADDONS_DIR}/missing-import-addon/foobar.ts`, "export const whatever = () => 'whatever';");
         system.writeFile(
-            `${ADDONS_DIR}/missing-import-addon/index.ts`,
-            "import { missingFunction } from './addon'; export const activate = () => missingFunction();"
+            `${ADDONS_DIR}/missing-import-addon/addon.ts`,
+            "import { missingFunction } from './foobar'; export const activate = () => missingFunction();"
         );
         target.reportDiagnostic = jest.fn();
 
@@ -712,9 +713,29 @@ describe("Addon Compilation", () => {
         expect(target.reportDiagnostic).toHaveBeenCalledWith(
             expect.objectContaining({
                 category: expect.any(Number),
-                messageText: expect.stringContaining(`Addon "missing-import-addon" does not export an "activate" function and will be ignored`),
+                messageText: expect.stringContaining(
+                    `Cannot find module '${ADDONS_DIR}/lib/missing-import-addon/addon.js' from 'src/compiler/addons/AddonRegistry.ts'`
+                ),
             })
         );
+    });
+
+    it("reports no warning with missing addon module in shared directory", () => {
+        const system = createSystem({}, { virtual: true });
+        const target = new ReporterMock(system);
+        jest.spyOn(target, "reportDiagnostic").mockImplementation(() => {
+            console.log("reportDiagnostic");
+        });
+        system.createDirectory(ADDONS_DIR);
+        system.createDirectory(`${ADDONS_DIR}/shared-directory`);
+        system.createDirectory(`${ADDONS_DIR}/addon-directory`);
+        system.writeFile(`${ADDONS_DIR}/shared-directory/index.ts`, "export const foo = () => 'foo';");
+        system.writeFile(`${ADDONS_DIR}/addon-directory/index.ts`, "import { foo } from '../shared-directory'; export const activate = () => foo();");
+
+        const testObj = new AddonRegistry({ addonsDir: ADDONS_DIR, reporter: target, system });
+
+        testObj.getAvailableAddons();
+        expect(target.reportDiagnostic).not.toHaveBeenCalled();
     });
 
     it("prioritizes addon.js over addon.ts when both exist", () => {

--- a/packages/core/src/compiler/addons/AddonRegistry.ts
+++ b/packages/core/src/compiler/addons/AddonRegistry.ts
@@ -515,7 +515,7 @@ export class AddonRegistry {
             // Handle both ES modules (default export) and CommonJS modules
             const addonModule = module?.default || module;
 
-            if (!addonModule || typeof addonModule.activate !== "function") {
+            if (!addonModule || (path.basename(importPath, path.extname(importPath)) === "addon" && typeof addonModule.activate !== "function")) {
                 // Return undefined and log warning instead of throwing error (restore original behavior)
                 this.config.reporter?.reportDiagnostic(
                     new WarnMessage(`Addon "${addonName}" does not export an "activate" function and will be ignored`)


### PR DESCRIPTION
This pull request primarily improves the reliability and accuracy of addon module resolution and diagnostics in the addon compilation system, as well as enhances the related test coverage. The most important changes are grouped below:

### Test Improvements and Coverage

* Changed test setup in `command.spec.ts` to use `beforeEach` instead of `beforeAll` for mocking `console.time`, ensuring a fresh mock for each test and preventing state leakage.
* Updated and expanded tests in `AddonRegistry.spec.ts` to:
  - Write a new test addon file (`foobar.ts`) and adjust the import path in the test addon to improve test accuracy.
  - Update the expected diagnostic message to check for missing module errors instead of missing exports, reflecting improved error reporting.
  - Add a new test to ensure that missing addon modules in shared directories do not trigger unnecessary warnings, improving test coverage for shared code scenarios.

### Addon Module Resolution Logic

* Updated the logic in `AddonRegistry.ts` to only warn about missing `activate` exports for files named `addon`, preventing false positives for other module files and improving diagnostic accuracy.