### PR TITLE
F Add markFileAsAddonProcessed method to track processed files in AddonContext

### DIFF
--- a/packages/api/src/addons/AddonContext.ts
+++ b/packages/api/src/addons/AddonContext.ts
@@ -121,4 +121,13 @@ export interface AddonContext<O = unknown> {
      * @param processor Function `(fileNames: string[]) => void` that is executed after the compilation of all files. Must not be null.
      */
     registerResultProcessor(processor: ResultProcessor): void;
+
+    /**
+     * Mark a file as having been processed by an addon.
+     * This is used to track which files should be emitted when addonEmitOnly mode is enabled.
+     * Use this for files that are processed but produce identical output (e.g., barrel files with re-exports).
+     *
+     * @param fileName Path to the file to mark as processed.
+     */
+    markFileAsAddonProcessed(fileName: string): void;
 }

--- a/packages/core/src/compiler/compilation/CompilationContext.spec.ts
+++ b/packages/core/src/compiler/compilation/CompilationContext.spec.ts
@@ -350,7 +350,7 @@ describe("markFileAsAddonProcessed", () => {
     });
 
     it("should return immutable copy of addon processed files", () => {
-        testObj.markFileAsAddonProcessed("path/file.ts");
+        testObj.markFileAsAddonProcessed("/path/file.ts");
 
         const processedFiles = testObj.getAddonProcessedFiles();
         processedFiles.add("should-not-affect-original");

--- a/packages/core/src/compiler/compilation/CompilationContext.spec.ts
+++ b/packages/core/src/compiler/compilation/CompilationContext.spec.ts
@@ -300,3 +300,52 @@ describe("addVirtualFile", () => {
         expect(testSystem.fileExists("/unexpected/test.ts")).toBe(false);
     });
 });
+
+describe("markFileAsAddonProcessed", () => {
+    it("should mark file as processed", () => {
+        testObj.markFileAsAddonProcessed("/path/to/file.ts");
+
+        expect(testObj.isFileProcessedByAddon("/path/to/file.ts")).toBe(true);
+    });
+
+    it("should normalize paths before marking", () => {
+        // Both mark and check should resolve to the same path
+        testObj.markFileAsAddonProcessed("/path/to/file.ts");
+
+        // The system resolves paths, so check with the same input works
+        expect(testObj.isFileProcessedByAddon("/path/to/file.ts")).toBe(true);
+    });
+
+    it("should handle different path formats for same file", () => {
+        // Mark with one format
+        testObj.markFileAsAddonProcessed("/path/file.ts");
+
+        // Should be found with same normalized path
+        expect(testObj.isFileProcessedByAddon("/path/file.ts")).toBe(true);
+    });
+
+    it("should be idempotent", () => {
+        testObj.markFileAsAddonProcessed("/path/file.ts");
+        testObj.markFileAsAddonProcessed("/path/file.ts");
+
+        expect(testObj.isFileProcessedByAddon("/path/file.ts")).toBe(true);
+    });
+
+    it("should return false for unmarked files", () => {
+        expect(testObj.isFileProcessedByAddon("/other/file.ts")).toBe(false);
+    });
+
+    it("should mark file when addInputFile is called", () => {
+        testSystem.writeFile("/expected/test.ts", "export const test = 1;");
+
+        testObj.addInputFile("/expected/test.ts");
+
+        expect(testObj.isFileProcessedByAddon("/expected/test.ts")).toBe(true);
+    });
+
+    it("should mark file when addVirtualFile is called", () => {
+        testObj.addVirtualFile("/virtual/test.ts", "export const test = 1;");
+
+        expect(testObj.isFileProcessedByAddon("/virtual/test.ts")).toBe(true);
+    });
+});

--- a/packages/core/src/compiler/compilation/CompilationContext.spec.ts
+++ b/packages/core/src/compiler/compilation/CompilationContext.spec.ts
@@ -348,4 +348,14 @@ describe("markFileAsAddonProcessed", () => {
 
         expect(testObj.isFileProcessedByAddon("/virtual/test.ts")).toBe(true);
     });
+
+    it("should return immutable copy of addon processed files", () => {
+        testObj.markFileAsAddonProcessed("/path/file.ts");
+
+        const processedFiles = testObj.getAddonProcessedFiles();
+        processedFiles.add("should-not-affect-original");
+
+        expect(testObj.getAddonProcessedFiles()).not.toContain("should-not-affect-original");
+        expect(testObj.getAddonProcessedFiles()).toContain("/path/file.ts");
+    });
 });

--- a/packages/core/src/compiler/compilation/CompilationContext.spec.ts
+++ b/packages/core/src/compiler/compilation/CompilationContext.spec.ts
@@ -350,7 +350,7 @@ describe("markFileAsAddonProcessed", () => {
     });
 
     it("should return immutable copy of addon processed files", () => {
-        testObj.markFileAsAddonProcessed("/path/file.ts");
+        testObj.markFileAsAddonProcessed("path/file.ts");
 
         const processedFiles = testObj.getAddonProcessedFiles();
         processedFiles.add("should-not-affect-original");

--- a/packages/core/src/compiler/compilation/CompilationContext.ts
+++ b/packages/core/src/compiler/compilation/CompilationContext.ts
@@ -307,6 +307,14 @@ export class CompilationContext implements AddonContext {
     }
 
     /**
+     * Get all files that have been marked as addon-processed.
+     * Returns a copy of the internal set, not the original.
+     */
+    public getAddonProcessedFiles(): Set<string> {
+        return new Set(this.addonProcessedFiles);
+    }
+
+    /**
      * Set the current source file being processed.
      * Used to mark the source file when generators interact with compilation via addInputFile/addVirtualFile.
      * @internal

--- a/packages/webpack/src/WebpackAddonContext.spec.ts
+++ b/packages/webpack/src/WebpackAddonContext.spec.ts
@@ -391,11 +391,11 @@ describe("WebpackAddonContext", () => {
         it("should report debug message when marking file", () => {
             jest.clearAllMocks();
 
-            testObj.markFileAsAddonProcessed("/path/file.ts");
+            testObj.markFileAsAddonProcessed("path/file.ts");
 
             expect(mockReporter.reportDiagnostic).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    messageText: expect.stringContaining("Marked file /path/file.ts as addon-processed"),
+                    messageText: expect.stringContaining("Marked file /resolved/path/file.ts as addon-processed"),
                 })
             );
         });

--- a/packages/webpack/src/WebpackAddonContext.spec.ts
+++ b/packages/webpack/src/WebpackAddonContext.spec.ts
@@ -388,6 +388,32 @@ describe("WebpackAddonContext", () => {
             expect(testObj.getAddonProcessedFiles()).toContain("/resolved/path/file.ts");
         });
 
+        it("should merge local and compilation context files in getAddonProcessedFiles", () => {
+            const mockCompilationContext = {
+                markFileAsAddonProcessed: jest.fn(),
+                isFileProcessedByAddon: jest.fn(),
+                getAddonProcessedFiles: jest.fn().mockReturnValue(new Set(["/context/file.ts"])),
+            };
+
+            const testObjWithContext = new WebpackAddonContext(
+                mockSystem,
+                mockReporter,
+                "test-profile",
+                undefined,
+                mockCompilationContext as any,
+                mockLoaderContext,
+                mockWebpackCompilation,
+                true
+            );
+
+            testObjWithContext.markFileAsAddonProcessed("/local/file.ts");
+
+            const allFiles = testObjWithContext.getAddonProcessedFiles();
+            expect(allFiles).toContain("/local/file.ts");
+            expect(allFiles).toContain("/context/file.ts");
+            expect(allFiles.size).toBe(2);
+        });
+
         it("should report debug message when marking file", () => {
             jest.clearAllMocks();
 

--- a/packages/webpack/src/WebpackAddonContext.spec.ts
+++ b/packages/webpack/src/WebpackAddonContext.spec.ts
@@ -379,13 +379,13 @@ describe("WebpackAddonContext", () => {
         });
 
         it("should return immutable copy of addon processed files", () => {
-            testObj.markFileAsAddonProcessed("/path/file.ts");
+            testObj.markFileAsAddonProcessed("path/file.ts");
 
             const processedFiles = testObj.getAddonProcessedFiles();
             processedFiles.add("should-not-affect-original");
 
             expect(testObj.getAddonProcessedFiles()).not.toContain("should-not-affect-original");
-            expect(testObj.getAddonProcessedFiles()).toContain("/path/file.ts");
+            expect(testObj.getAddonProcessedFiles()).toContain("/resolved/path/file.ts");
         });
 
         it("should report debug message when marking file", () => {

--- a/packages/webpack/src/WebpackAddonContext.spec.ts
+++ b/packages/webpack/src/WebpackAddonContext.spec.ts
@@ -306,4 +306,98 @@ describe("WebpackAddonContext", () => {
             expect(testObj.getFilesToRemove()).not.toContain("should-not-affect-original");
         });
     });
+
+    describe("markFileAsAddonProcessed", () => {
+        it("should mark file as processed", () => {
+            testObj.markFileAsAddonProcessed("/path/to/file.ts");
+
+            expect(testObj.isFileProcessedByAddon("/path/to/file.ts")).toBe(true);
+        });
+
+        it("should normalize paths before marking", () => {
+            testObj.markFileAsAddonProcessed("src/index.ts");
+
+            // Check with resolved path
+            expect(testObj.isFileProcessedByAddon("/resolved/src/index.ts")).toBe(true);
+        });
+
+        it("should be idempotent", () => {
+            testObj.markFileAsAddonProcessed("/path/file.ts");
+            testObj.markFileAsAddonProcessed("/path/file.ts");
+
+            expect(testObj.isFileProcessedByAddon("/path/file.ts")).toBe(true);
+        });
+
+        it("should return false for unmarked files", () => {
+            expect(testObj.isFileProcessedByAddon("/other/file.ts")).toBe(false);
+        });
+
+        it("should delegate to compilation context when available", () => {
+            const mockCompilationContext = {
+                markFileAsAddonProcessed: jest.fn(),
+                isFileProcessedByAddon: jest.fn().mockReturnValue(true),
+            };
+
+            const testObjWithContext = new WebpackAddonContext(
+                mockSystem,
+                mockReporter,
+                "test-profile",
+                undefined,
+                mockCompilationContext as any,
+                mockLoaderContext,
+                mockWebpackCompilation,
+                true
+            );
+
+            testObjWithContext.markFileAsAddonProcessed("/path/file.ts");
+
+            expect(mockCompilationContext.markFileAsAddonProcessed).toHaveBeenCalledWith("/path/file.ts");
+        });
+
+        it("should check compilation context when file not in local tracking", () => {
+            const mockCompilationContext = {
+                markFileAsAddonProcessed: jest.fn(),
+                isFileProcessedByAddon: jest.fn().mockReturnValue(true),
+            };
+
+            const testObjWithContext = new WebpackAddonContext(
+                mockSystem,
+                mockReporter,
+                "test-profile",
+                undefined,
+                mockCompilationContext as any,
+                mockLoaderContext,
+                mockWebpackCompilation,
+                true
+            );
+
+            // Don't mark locally, but compilation context says it's processed
+            const result = testObjWithContext.isFileProcessedByAddon("/path/file.ts");
+
+            expect(result).toBe(true);
+            expect(mockCompilationContext.isFileProcessedByAddon).toHaveBeenCalledWith("/path/file.ts");
+        });
+
+        it("should return immutable copy of addon processed files", () => {
+            testObj.markFileAsAddonProcessed("/path/file.ts");
+
+            const processedFiles = testObj.getAddonProcessedFiles();
+            processedFiles.add("should-not-affect-original");
+
+            expect(testObj.getAddonProcessedFiles()).not.toContain("should-not-affect-original");
+            expect(testObj.getAddonProcessedFiles()).toContain("/path/file.ts");
+        });
+
+        it("should report debug message when marking file", () => {
+            jest.clearAllMocks();
+
+            testObj.markFileAsAddonProcessed("/path/file.ts");
+
+            expect(mockReporter.reportDiagnostic).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    messageText: expect.stringContaining("Marked file /path/file.ts as addon-processed"),
+                })
+            );
+        });
+    });
 });

--- a/packages/webpack/src/WebpackAddonContext.ts
+++ b/packages/webpack/src/WebpackAddonContext.ts
@@ -36,6 +36,7 @@ export class WebpackAddonContext implements AddonContext {
     private filesToRemove = new Set<string>();
     private assetDependencies = new Map<string, Set<string>>();
     private inputFilesToAdd = new Set<string>();
+    private addonProcessedFiles = new Set<string>();
     private debug: boolean;
 
     constructor(
@@ -418,6 +419,49 @@ export class WebpackAddonContext implements AddonContext {
      */
     getInputFilesToAdd(): Set<string> {
         return new Set(this.inputFilesToAdd);
+    }
+
+    /**
+     * Mark a file as having been processed by an addon.
+     * This is used to track which files should be emitted when addonEmitOnly mode is enabled.
+     * Use this for files that are processed but produce identical output (e.g., barrel files with re-exports).
+     */
+    markFileAsAddonProcessed(fileName: string): void {
+        const resolvedPath = this.system.resolvePath(fileName);
+        this.addonProcessedFiles.add(resolvedPath);
+
+        // Delegate to the compilation context if available
+        if (this.compilationContext) {
+            this.compilationContext.markFileAsAddonProcessed(fileName);
+        }
+        this.reportDebug(`WebpackAddonContext: Marked file ${resolvedPath} as addon-processed`);
+    }
+
+    /**
+     * Check if a file has been processed by an addon.
+     * Used to determine if a file should be emitted in addonEmitOnly mode.
+     */
+    isFileProcessedByAddon(fileName: string): boolean {
+        const resolvedPath = this.system.resolvePath(fileName);
+
+        // Check local tracking first
+        if (this.addonProcessedFiles.has(resolvedPath)) {
+            return true;
+        }
+
+        // Fall back to compilation context if available
+        if (this.compilationContext) {
+            return this.compilationContext.isFileProcessedByAddon(fileName);
+        }
+
+        return false;
+    }
+
+    /**
+     * Get all files that have been marked as addon-processed.
+     */
+    getAddonProcessedFiles(): Set<string> {
+        return new Set(this.addonProcessedFiles);
     }
 
     /**

--- a/packages/webpack/src/WebpackAddonContext.ts
+++ b/packages/webpack/src/WebpackAddonContext.ts
@@ -459,9 +459,16 @@ export class WebpackAddonContext implements AddonContext {
 
     /**
      * Get all files that have been marked as addon-processed.
+     * Returns a copy that includes both local tracking and compilation context files.
      */
     getAddonProcessedFiles(): Set<string> {
-        return new Set(this.addonProcessedFiles);
+        const files = new Set(this.addonProcessedFiles);
+        if (this.compilationContext) {
+            for (const file of this.compilationContext.getAddonProcessedFiles()) {
+                files.add(file);
+            }
+        }
+        return files;
     }
 
     /**


### PR DESCRIPTION
This pull request introduces a new mechanism for tracking files processed by addons, primarily to support scenarios where files should be emitted even if their output is unchanged (such as barrel files with re-exports). The changes add a new `markFileAsAddonProcessed` method to the `AddonContext` interface and implement it in the `WebpackAddonContext`, along with supporting methods and extensive test coverage to ensure correct behavior and integration with the compilation context.

**Addon-processed file tracking:**

* Added `markFileAsAddonProcessed(fileName: string): void` to the `AddonContext` interface, allowing addons to explicitly mark files as processed. This supports more accurate file emission control, especially in `addonEmitOnly` mode.
* Implemented `markFileAsAddonProcessed`, `isFileProcessedByAddon`, and `getAddonProcessedFiles` methods in `WebpackAddonContext`, including path normalization, idempotency, and delegation to the compilation context when present. [[1]](diffhunk://#diff-6b3a2503f974683beae2270dd36478d1ac87deb1efd6924cfe737b1dd278ced9R39) [[2]](diffhunk://#diff-6b3a2503f974683beae2270dd36478d1ac87deb1efd6924cfe737b1dd278ced9R424-R466)

**Testing and validation:**

* Added comprehensive tests for the new file tracking methods in both `CompilationContext.spec.ts` and `WebpackAddonContext.spec.ts`, covering path normalization, idempotency, context delegation, and debug reporting. [[1]](diffhunk://#diff-b91c499982372e54813b2debd7ede73b010720b6bce8bcb27949b4ce6ce3578bR303-R351) [[2]](diffhunk://#diff-ef52d9e9ccb1ef2c65524848f5cba1ba6eb57d833fddd875ddd87908a9f06921R309-R402)